### PR TITLE
Apply Ledger visual theme

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -96,7 +96,9 @@ button:focus-visible, a:focus-visible {
 }
 
 /* --- Type --- */
-.wordmark { font-size: 18px; font-weight: 700; letter-spacing: -0.02em; color: var(--ink); }
+.brand-text { display: flex; flex-direction: column; gap: 3px; }
+.wordmark { font-size: 26px; font-weight: 700; letter-spacing: -0.02em; color: var(--ink); line-height: 1; }
+.tagline { font-size: 12.5px; font-weight: 500; color: var(--muted); line-height: 1; }
 .micro-label {
     font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
     text-transform: uppercase; color: var(--muted);
@@ -113,13 +115,19 @@ button:focus-visible, a:focus-visible {
     padding-top: 16px; padding-bottom: 16px;
     display: flex; align-items: center; justify-content: space-between; gap: 16px;
 }
-.brand { display: flex; align-items: center; gap: 10px; }
+.brand { display: flex; align-items: center; gap: 10px; margin-top: 9px; }
 .brand:hover { text-decoration: none; }
-.logo-container { position: relative; display: inline-block; width: 24px; height: 24px; }
+.logo-container { position: relative; display: inline-block; width: 36px; height: 36px; }
 .wallet-icon {
-    font-size: 21px; position: absolute; left: 0; top: 0;
+    font-size: 34px; line-height: 1; position: absolute; left: 0; top: 0;
     color: var(--ink); animation: shake 3s infinite;
 }
+.money-icon {
+    font-size: 18px; line-height: 1; position: absolute; opacity: 0;
+    color: var(--accent);
+}
+.money-icon:nth-of-type(2) { animation: flyMoney 3s infinite; }
+.money-icon:nth-of-type(3) { animation: flyMoney 3s infinite; animation-delay: 0.5s; }
 .header-actions { display: flex; align-items: center; gap: 10px; min-width: 0; }
 .share-pill {
     display: flex; align-items: center; gap: 8px; min-width: 0;
@@ -129,7 +137,11 @@ button:focus-visible, a:focus-visible {
 .share-pill__icon { color: var(--muted); font-size: 15px; }
 .share-pill__url {
     font-size: 13px; color: var(--muted);
-    max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    max-width: 460px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.header-note {
+    font-size: 12px; color: var(--muted);
+    text-align: right; padding-bottom: 12px; margin-top: -6px;
 }
 .copy-btn {
     border: none; background: transparent; padding: 0;
@@ -144,7 +156,7 @@ button:focus-visible, a:focus-visible {
     font-size: 14px; display: inline-flex; align-items: center; justify-content: center;
     transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease, transform 0.1s ease;
 }
-.icon-btn:hover { border-color: var(--muted); }
+.icon-btn:hover { border-color: var(--muted); text-decoration: none; }
 .icon-btn:active { transform: scale(0.92); }
 
 /* --- Buttons --- */
@@ -446,10 +458,9 @@ button:focus-visible, a:focus-visible {
 .rates-note { font-size: 12.5px; color: var(--muted); }
 .rates-note .bi { margin-right: 6px; }
 
-/* --- Toasts --- */
+/* --- Toasts (inline, below the main app content) --- */
 .toast-container-ledger {
-    position: fixed; right: 16px; bottom: 16px; z-index: 100;
-    display: flex; flex-direction: column; gap: 8px;
+    display: flex; flex-direction: column; gap: 8px; align-items: center;
 }
 .toast-ledger {
     background: var(--surface); border: 1px solid var(--line);
@@ -477,7 +488,6 @@ button:focus-visible, a:focus-visible {
     .tabbar-mobile { display: flex; }
     body { padding-bottom: calc(72px + env(safe-area-inset-bottom)); }
     .share-pill__url { display: none; }
-    .toast-container-ledger { bottom: calc(84px + env(safe-area-inset-bottom)); }
     /* Prevent iOS focus zoom */
     .input-ledger, .select-ledger, .chip-input { font-size: 16px; }
     .input-title { font-size: 20px; }
@@ -497,6 +507,12 @@ button:focus-visible, a:focus-visible {
     0% { opacity: 0; transform: scale(0.9); }
     70% { transform: scale(1.02); }
     100% { opacity: 1; transform: scale(1); }
+}
+@keyframes flyMoney {
+    0% { opacity: 0; left: 10%; top: 40%; }
+    25% { opacity: 1; left: 65%; top: -35%; }
+    50% { opacity: 0; left: 100%; top: -75%; }
+    100% { opacity: 0; left: 100%; top: -75%; }
 }
 .anim-fade-up { animation: fadeUp 0.25s ease; }
 .anim-pop-in { animation: popIn 0.4s ease; }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,302 +1,502 @@
-.table {
-    margin-bottom: 0;
+/* BrokeWise — "Ledger" theme
+   Paper-and-ink aesthetic: hairline borders, no drop shadows, single emerald accent.
+   Tokens and core styles adapted from design_handoff_ledger_theme/ledger.css. */
+
+:root {
+    --bg: #FAFAF7;
+    --surface: #FFFFFF;
+    --ink: #1A1A17;
+    --muted: #8A8A80;
+    --line: #E7E6E0;
+    --line-input: #DDDCD4;
+    --accent: #0F7B5F;
+    --accent-soft: rgba(15, 123, 95, 0.08);
+    --neg: #B0483A;
+    --neg-soft: rgba(176, 72, 58, 0.07);
+    --well: #FAFAF7;
+
+    --radius-s: 8px;
+    --radius-m: 10px;
+    --radius-l: 12px;
+    --font: "Instrument Sans", -apple-system, BlinkMacSystemFont, sans-serif;
+    --select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%238A8A80' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    color-scheme: light;
 }
 
-.participant-badge {
-    margin-right: 0.5rem;
-    margin-bottom: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    cursor: default;
-    transition: all 0.2s ease;
+[data-theme="dark"] {
+    --bg: #131311;
+    --surface: #222220;
+    --ink: #EFEEE8;
+    --muted: #9C9C92;
+    --line: #3E3E38;
+    --line-input: #3E3E38;
+    --accent: #3FBF95;
+    --accent-soft: rgba(63, 191, 149, 0.14);
+    --neg: #D98A7C;
+    --neg-soft: rgba(217, 138, 124, 0.12);
+    --well: #2B2B27;
+    --select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%239C9C92' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    color-scheme: dark;
 }
 
-.participant-badge i {
-    margin-left: 0.5rem;
-    cursor: pointer;
-    opacity: 0.7;
-}
-
-.participant-badge i:hover {
-    opacity: 1;
-}
-
-.card {
-    transition: transform 0.2s ease;
-}
-
-.expense-entry:hover {
-    transform: translateY(-2px);
-}
-
-#settlementResults {
-    font-size: 1.1rem;
-}
-
-.positive-amount {
-    color: var(--bs-success);
-    font-weight: 500;
-}
-
-.negative-amount {
-    color: var(--bs-danger);
-    font-weight: 500;
-}
-
-.amounts-mismatch-warning {
-    font-size: 0.9rem;
-}
-
-.input-group {
-    margin-bottom: 0.5rem;
-}
-
-.invalid-entry {
-    border-radius: 0.375rem;
-    box-shadow: 0 0 0 0.2rem rgba(var(--bs-danger-rgb), 0.12);
-}
-
-.invalid-entry .form-control,
-.invalid-entry .form-select {
-    background-color: rgba(var(--bs-danger-rgb), 0.04);
-}
-
-.btn-group {
-    gap: 0.5rem;
-}
-
-.total-paid,
-.total-split {
-    font-size: 1rem;
-    padding: 0.5rem 1rem;
-}
-
-.card-header input.form-control {
-    border: none;
-    background: transparent;
-    padding: 0;
-    font-weight: 500;
-    font-size: 1.1rem;
-}
-
-.card-header input.form-control:focus {
-    box-shadow: none;
-    border-bottom: 2px solid var(--bs-primary);
-}
-
-.table td {
-    vertical-align: middle;
-}
-
-.tab-content {
-    padding-top: 1rem;
-}
-
-/* Styling for the split-item entries in expense table */
-.split-item {
-    border-bottom: 1px solid rgba(0,0,0,0.05);
-    padding: 4px 2px;
-}
-
-.split-item:last-child {
-    border-bottom: none;
-}
-
-.split-item .text-muted {
-    font-size: 0.85rem;
-}
-
-/* Mobile card styling for expenses */
-.expense-card {
-    transition: transform 0.2s;
-    border-left: 4px solid var(--bs-primary);
-}
-
-.expense-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 .5rem 1rem rgba(0,0,0,.15);
-}
-
-.expense-card .card-header {
-    background-color: rgba(var(--bs-primary-rgb), 0.05);
-}
-
-.expense-card .badge {
-    font-size: 1rem;
-    padding: 0.5rem 0.75rem;
-}
-
-@media (max-width: 767.98px) {
-    .btn-group .btn {
-        padding: 0.375rem 0.75rem;
-    }
-    
-    .btn-group .btn i {
-        margin-right: 0.25rem;
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --bg: #131311;
+        --surface: #222220;
+        --ink: #EFEEE8;
+        --muted: #9C9C92;
+        --line: #3E3E38;
+        --line-input: #3E3E38;
+        --accent: #3FBF95;
+        --accent-soft: rgba(63, 191, 149, 0.14);
+        --neg: #D98A7C;
+        --neg-soft: rgba(217, 138, 124, 0.12);
+        --well: #2B2B27;
+        --select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%239C9C92' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+        color-scheme: dark;
     }
 }
 
-.expense-tabs-container {
-    width: 100%;
-    overflow: hidden;
-    border: 1px solid #dee2e6;
-    border-radius: 0.25rem;
-}
+/* --- Base --- */
+*, *::before, *::after { box-sizing: border-box; }
 
-.tab-list-mobile {
-    display: flex;
-    flex-wrap: nowrap;
-    width: 100%;
+body {
     margin: 0;
-    padding: 0;
-    list-style: none;
-    border-bottom: none;
-}
-
-.tab-list-mobile .nav-item {
-    flex: 1; /* Make tabs take equal width */
-    text-align: center;
-    min-width: auto; /* Allow tabs to shrink */
-    margin: 0; /* Remove margins between tabs */
-    padding: 0;
-    font-size: 1rem; /* Reset font size */
-    display: flex; /* Use flexbox for the items */
-    border-radius: 0;
-}
-
-.tab-list-mobile .nav-link {
-    flex: 1;
-    border-radius: 0;
-    border: none;
-    border-bottom: 1px solid #dee2e6;
-    padding: 0.75rem 0;
-}
-
-.tab-list-mobile .nav-link.active {
-    border-bottom: none;
-    background-color: #20c997; /* Bootstrap teal */
-    color: white;
-}
-
-/* Remove any space or border between tabs by using a single border between them */
-.tab-list-mobile .nav-item:first-child {
-    border-right: 1px solid #dee2e6;
-}
-
-.nav-tabs .nav-link {
+    min-height: 100vh;
     display: flex;
-    align-items: center;
-    justify-content: center; /* Center content horizontally */
-    gap: 0.5rem;
-    padding: 0.5rem; /* Reduce padding for small screens */
-    white-space: nowrap; /* Prevent text wrapping */
-    font-size: 0.9rem; /* Slightly smaller font on mobile */
-    border-radius: 0; /* Remove border radius */
-    margin: 0; /* Remove any margin */
+    flex-direction: column;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--font);
+    font-size: 14px;
+    line-height: 1.5;
+    transition: background 0.25s ease, color 0.25s ease;
 }
 
-/* Further adjustments for extra small screens */
-@media (max-width: 375px) {
-    .nav-tabs .nav-link {
-        padding: 0.4rem 0.3rem;
-        font-size: 0.85rem;
-    }
-    
-    .nav-tabs .nav-link i {
-        margin-right: 0.2rem;
-        font-size: 0.9rem;
-    }
+.container-ledger { max-width: 880px; width: 100%; margin: 0 auto; padding-left: 24px; padding-right: 24px; }
+.page-main { padding-top: 32px; flex: 1; display: flex; flex-direction: column; gap: 28px; }
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+::selection { background: rgba(15, 123, 95, 0.18); }
+
+button { font-family: var(--font); }
+button:focus-visible, a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+[hidden] { display: none !important; }
+
+/* Theme-transition surfaces */
+.site-header, .site-footer, .card-ledger, .chip, .share-pill, .icon-btn,
+.tabbar-mobile, .expense-card-m, .balance-card, .transfers-card,
+.table-footer, .toast-ledger, .settle-hint {
+    transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
 }
 
-.table-responsive {
-    margin: -1rem;
-    padding: 1rem;
-    max-height: 500px;
-    overflow-y: auto;
+/* --- Type --- */
+.wordmark { font-size: 18px; font-weight: 700; letter-spacing: -0.02em; color: var(--ink); }
+.micro-label {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--muted);
 }
+.amount { font-variant-numeric: tabular-nums; }
+.amount--pos { color: var(--accent); }
+.amount--neg { color: var(--neg); }
+.helper-text { font-size: 13px; color: var(--muted); }
+.helper-text .bi { margin-right: 6px; }
 
-.currency-select-wide {
-    min-width: 200px !important;
+/* --- Header --- */
+.site-header { border-bottom: 1px solid var(--line); background: var(--bg); }
+.header-inner {
+    padding-top: 16px; padding-bottom: 16px;
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
 }
-
-.expense-description {
-    font-size: 1.1rem;
-}
-
-.expense-description:focus {
-    box-shadow: none;
-    border-color: var(--bs-primary);
-}
-
-/* Logo animation styles */
-.btn-teal {
-    background-color: #20c997;
-    color: white;
-}
-
-.btn-teal:hover {
-    background-color: #1ba884;
-    color: white;
-}
-
-.logo-container {
-    position: relative;
-    display: inline-block;
-    width: 40px;
-    height: 40px;
-}
-
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand:hover { text-decoration: none; }
+.logo-container { position: relative; display: inline-block; width: 24px; height: 24px; }
 .wallet-icon {
-    font-size: 1.8rem;
-    position: absolute;
-    left: 0;
-    top: 0;
-    transform-origin: center;
-    animation: shake 3s infinite;
+    font-size: 21px; position: absolute; left: 0; top: 0;
+    color: var(--ink); animation: shake 3s infinite;
+}
+.header-actions { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.share-pill {
+    display: flex; align-items: center; gap: 8px; min-width: 0;
+    border: 1px solid var(--line); border-radius: var(--radius-s);
+    padding: 7px 12px; background: var(--surface);
+}
+.share-pill__icon { color: var(--muted); font-size: 15px; }
+.share-pill__url {
+    font-size: 13px; color: var(--muted);
+    max-width: 260px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.copy-btn {
+    border: none; background: transparent; padding: 0;
+    font-size: 12.5px; font-weight: 600; color: var(--accent);
+    cursor: pointer; white-space: nowrap; transition: transform 0.1s ease;
+}
+.copy-btn:active { transform: scale(0.94); }
+.icon-btn {
+    width: 34px; height: 34px; flex-shrink: 0;
+    border: 1px solid var(--line); border-radius: var(--radius-s);
+    background: var(--surface); color: var(--ink); cursor: pointer;
+    font-size: 14px; display: inline-flex; align-items: center; justify-content: center;
+    transition: background 0.25s ease, border-color 0.25s ease, color 0.25s ease, transform 0.1s ease;
+}
+.icon-btn:hover { border-color: var(--muted); }
+.icon-btn:active { transform: scale(0.92); }
+
+/* --- Buttons --- */
+.btn-ledger {
+    font-family: var(--font); font-size: 14px; font-weight: 600;
+    border-radius: var(--radius-s); padding: 10px 20px; cursor: pointer;
+    border: none; background: var(--ink); color: var(--bg);
+    transition: transform 0.1s ease, opacity 0.2s ease, background 0.25s ease, color 0.25s ease;
+}
+.btn-ledger:hover { opacity: 0.85; }
+.btn-ledger:active { transform: scale(0.97); }
+.btn-ledger .bi { margin-right: 4px; }
+.btn-ledger.is-disabled { opacity: 0.45; }
+.btn-ledger--secondary {
+    background: transparent; color: var(--ink);
+    border: 1px solid var(--line-input);
+    transition: border-color 0.15s ease, transform 0.1s ease, background 0.25s ease, color 0.25s ease;
+}
+.btn-ledger--secondary:hover { border-color: var(--ink); opacity: 1; }
+.btn-ledger--compact { padding: 9px 16px; font-size: 13.5px; }
+.btn-ledger--compact .bi { margin-right: 6px; }
+.btn-link-accent {
+    background: none; border: none; padding: 0; cursor: pointer;
+    font: 600 13px var(--font); color: var(--accent);
+}
+.btn-link-accent:hover { text-decoration: underline; }
+.btn-link-muted {
+    background: none; border: none; padding: 0; cursor: pointer;
+    font: 600 13px var(--font); color: var(--muted);
+    transition: color 0.15s ease;
+}
+.btn-link-muted:hover { color: var(--ink); }
+
+/* --- Sections --- */
+.section { display: flex; flex-direction: column; gap: 10px; }
+
+/* --- People chips --- */
+.people-row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+.chip {
+    display: inline-flex; align-items: center; gap: 8px;
+    border: 1px solid var(--line); background: var(--surface);
+    border-radius: var(--radius-s); padding: 7px 12px;
+    font-size: 14px; font-weight: 500;
+    animation: fadeUp 0.25s ease;
+}
+.chip__x {
+    color: var(--muted); cursor: pointer; border: none; background: none;
+    padding: 0; font-size: 14px; line-height: 1; display: inline-flex;
+    transition: color 0.15s ease;
+}
+.chip__x:hover { color: var(--neg); }
+.chip--add {
+    display: inline-flex; align-items: center; gap: 6px;
+    border: 1px dashed var(--line-input); background: transparent;
+    border-radius: var(--radius-s); padding: 7px 12px;
+    font-size: 14px; font-family: var(--font); color: var(--muted); cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+.chip--add:hover { color: var(--accent); border-color: var(--accent); }
+.chip-input {
+    border: 1px solid var(--accent); background: var(--surface);
+    border-radius: var(--radius-s); padding: 7px 12px;
+    font-size: 14px; font-family: var(--font); color: var(--ink);
+    outline: none; width: 110px;
 }
 
-.money-icon {
-    font-size: 1.2rem;
-    position: absolute;
-    opacity: 0;
-    color: var(--bs-success);
+/* --- Tabs (desktop) --- */
+.tabs-ledger { display: flex; gap: 24px; border-bottom: 1px solid var(--line); }
+.tab-ledger {
+    background: none; border: none; cursor: pointer;
+    font: 600 14px var(--font); color: var(--muted);
+    padding: 0 2px 10px; margin-bottom: -1px;
+    border-bottom: 2px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+}
+.tab-ledger.active { color: var(--ink); border-bottom-color: var(--ink); }
+.tab-count { font-size: 12px; color: var(--muted); font-weight: 500; }
+
+/* --- Mobile bottom tab bar (<700px) --- */
+.tabbar-mobile {
+    position: fixed; inset: auto 0 0 0; z-index: 50;
+    display: none; background: var(--surface);
+    border-top: 1px solid var(--line);
+    padding: 6px 8px;
+    padding-bottom: max(18px, env(safe-area-inset-bottom));
+}
+.tabbar-mobile button {
+    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 2px;
+    padding: 8px 0; background: none; border: none; cursor: pointer;
+    font: 600 11px var(--font); color: var(--muted);
+    transition: color 0.15s ease;
+}
+.tabbar-mobile button .bi { font-size: 20px; }
+.tabbar-mobile button.active { color: var(--ink); }
+
+/* --- Tab panes --- */
+.tab-pane { display: flex; flex-direction: column; gap: 20px; }
+
+/* --- Cards / empty states --- */
+.card-ledger {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-m);
+}
+.card-ledger--empty {
+    background: var(--surface);
+    border: 1px dashed var(--line-input);
+    border-radius: var(--radius-m);
+    padding: 48px 24px;
+    display: flex; flex-direction: column; align-items: center; gap: 10px;
+    text-align: center;
+}
+.empty-icon { font-size: 28px; color: var(--muted); }
+.empty-title { font-size: 16px; font-weight: 600; }
+.empty-body { font-size: 14px; color: var(--muted); max-width: 380px; }
+.card-ledger--empty .btn-ledger { margin-top: 8px; }
+
+/* --- Inputs & selects --- */
+.input-ledger, .select-ledger {
+    font-family: var(--font); font-size: 14px; color: var(--ink);
+    background: var(--surface); border: 1px solid var(--line-input);
+    border-radius: var(--radius-s); padding: 8px 12px; outline: none;
+    transition: border-color 0.15s ease, background 0.25s ease, color 0.25s ease;
+}
+.input-ledger:focus { border-color: var(--accent); }
+.select-ledger {
+    appearance: none; -webkit-appearance: none;
+    background-image: var(--select-arrow);
+    background-repeat: no-repeat;
+    background-position: right 10px center;
+    padding-right: 28px;
+    cursor: pointer;
+}
+.select-ledger:focus-visible { border-color: var(--accent); outline: none; }
+.person-select { background-color: var(--well); font-weight: 500; padding: 8px 10px; padding-right: 28px; }
+.currency-select { font-size: 13px; color: var(--muted); padding: 8px 8px; padding-right: 26px; background-position: right 8px center; }
+.amount-input {
+    text-align: right; font-variant-numeric: tabular-nums;
+    flex: 1; min-width: 0;
+}
+.input-title {
+    display: block; width: 100%;
+    border: none; border-bottom: 1px solid var(--line); border-radius: 0;
+    padding: 4px 0 10px; font-size: 20px; font-weight: 600;
+    font-family: var(--font); color: var(--ink);
+    background: transparent; outline: none;
+    transition: border-color 0.2s ease, color 0.25s ease;
+}
+.input-title:focus { border-bottom-color: var(--accent); }
+.input-title::placeholder, .input-ledger::placeholder { color: var(--muted); opacity: 0.7; }
+
+/* --- Expense form --- */
+.expense-form { padding: 24px; display: flex; flex-direction: column; gap: 20px; }
+.form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 24px; }
+.form-col { display: flex; flex-direction: column; gap: 10px; }
+.form-col > .btn-link-accent { align-self: flex-start; }
+.col-head { display: flex; justify-content: space-between; align-items: center; }
+.col-head .btn-link-accent { font-size: 12px; }
+.entry-rows { display: flex; flex-direction: column; gap: 10px; }
+.entry-row { display: flex; align-items: center; gap: 8px; animation: fadeUp 0.2s ease; }
+.entry-row.is-invalid .amount-input { border-color: var(--neg); background-color: var(--neg-soft); }
+.row-x {
+    background: none; border: none; padding: 0; line-height: 1;
+    color: var(--muted); cursor: pointer; font-size: 16px;
+    display: inline-flex; transition: color 0.15s ease;
+}
+.row-x:hover { color: var(--neg); }
+.form-footer {
+    display: flex; justify-content: space-between; align-items: center;
+    border-top: 1px solid var(--line); padding-top: 16px;
+    flex-wrap: wrap; gap: 12px;
+}
+.totals-indicator {
+    font-size: 13px; color: var(--muted);
+    display: inline-flex; align-items: center; gap: 6px;
+    transition: color 0.2s ease;
+}
+.totals-indicator.is-matched { color: var(--accent); }
+.form-actions { display: flex; align-items: center; gap: 14px; }
+
+/* --- Expenses table (desktop) --- */
+.expense-table-card { overflow: hidden; }
+.expense-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.expense-table th {
+    text-align: left; padding: 12px 16px;
+    font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--muted);
+    border-bottom: 1px solid var(--line);
+}
+.expense-table td { padding: 14px 16px; border-bottom: 1px solid var(--line); }
+.expense-table tbody tr { transition: background 0.15s ease; }
+.expense-table tbody tr:hover { background: var(--well); }
+.expense-table .cell-title { font-weight: 600; }
+.expense-table .cell-amount { text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; }
+.expense-table .cell-actions { text-align: right; white-space: nowrap; }
+.person-line { padding: 2px 0; }
+.person-line .orig { color: var(--muted); font-size: 13px; font-variant-numeric: tabular-nums; }
+.row-action {
+    background: none; border: none; padding: 0;
+    color: var(--muted); cursor: pointer; font-size: 14px;
+    transition: color 0.15s ease;
+}
+.row-action--edit { margin-right: 12px; }
+.row-action--edit:hover { color: var(--ink); }
+.row-action--delete:hover { color: var(--neg); }
+.table-footer {
+    padding: 12px 16px; display: flex; justify-content: space-between; align-items: center;
+    background: var(--well);
+}
+.foot-count { font-size: 13px; color: var(--muted); }
+.foot-total { font-size: 14px; font-weight: 600; font-variant-numeric: tabular-nums; }
+
+/* --- Expenses cards (mobile) --- */
+.expense-cards { display: flex; flex-direction: column; gap: 12px; }
+.expense-card-m {
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: var(--radius-l); padding: 16px;
+    display: flex; flex-direction: column; gap: 10px;
+    animation: fadeUp 0.25s ease;
+}
+.ecm-head { display: flex; justify-content: space-between; align-items: baseline; gap: 12px; }
+.ecm-title { font-size: 16px; font-weight: 600; }
+.ecm-total { font-size: 16px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.ecm-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.ecm-col { display: flex; flex-direction: column; gap: 4px; }
+.ecm-label {
+    font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--muted);
+}
+.ecm-line { font-size: 13.5px; display: flex; justify-content: space-between; gap: 8px; }
+.ecm-line .name { font-weight: 500; }
+.ecm-line .orig { color: var(--muted); font-variant-numeric: tabular-nums; }
+.ecm-actions { display: flex; gap: 20px; border-top: 1px solid var(--line); padding-top: 10px; }
+.ecm-actions button {
+    background: transparent; border: none; padding: 4px 0;
+    font-size: 13px; font-weight: 600; font-family: var(--font); cursor: pointer;
+}
+.ecm-actions .bi { margin-right: 4px; }
+.ecm-edit { color: var(--muted); }
+.ecm-delete { color: var(--neg); }
+.list-footer-m { display: flex; justify-content: space-between; padding: 4px 4px 0; }
+
+/* --- Settle up --- */
+.settle-controls {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    flex-wrap: wrap; gap: 12px;
+}
+.settle-currency { display: flex; flex-direction: column; gap: 8px; }
+.settle-currency select { min-width: 180px; padding-top: 9px; padding-bottom: 9px; font-weight: 500; }
+.settle-hint {
+    border: 1px dashed var(--line-input); border-radius: var(--radius-m);
+    padding: 32px 24px; text-align: center; color: var(--muted); font-size: 14px;
+}
+.settle-results { display: flex; flex-direction: column; gap: 20px; }
+.settle-hint .bi { margin-right: 6px; }
+.balances-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 12px; }
+.balance-card {
+    border: 1px solid var(--line); background: var(--surface);
+    border-radius: var(--radius-m); padding: 16px;
+    animation: fadeUp 0.35s ease backwards;
+}
+.balance-name { font-size: 13px; color: var(--muted); margin-bottom: 2px; }
+.balance-net { font-size: 20px; font-weight: 700; font-variant-numeric: tabular-nums; }
+.balance-detail { font-size: 12.5px; color: var(--muted); margin-top: 6px; }
+.transfers-card {
+    border: 1px solid var(--line); background: var(--surface);
+    border-radius: var(--radius-m); padding: 20px 24px;
+    animation: fadeUp 0.35s ease 0.25s backwards;
+}
+.transfers-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
+.tap-hint { font-size: 12.5px; color: var(--muted); }
+.transfers-list { display: flex; flex-direction: column; gap: 10px; }
+.transfer-row {
+    display: flex; align-items: center; gap: 10px;
+    font-size: 15px; cursor: pointer;
+    border-radius: 6px; padding: 4px 6px; margin: 0 -6px;
+    transition: opacity 0.2s ease, background 0.15s ease;
+}
+.transfer-row:hover { background: var(--well); }
+.transfer-row .t-icon { color: var(--muted); font-size: 16px; transition: color 0.15s ease; }
+.transfer-row .t-name { font-weight: 600; }
+.transfer-row .t-arrow { color: var(--accent); }
+.transfer-row .leader { flex: 1; border-bottom: 1px dotted var(--line-input); margin: 0 4px; }
+.transfer-row .t-amount { font-weight: 700; font-variant-numeric: tabular-nums; color: var(--accent); }
+.transfer-row.is-paid { opacity: 0.55; }
+.transfer-row.is-paid .t-icon { color: var(--accent); }
+.transfer-row.is-paid .t-name, .transfer-row.is-paid .t-amount { text-decoration: line-through; }
+.all-paid-banner {
+    margin-top: 16px; background: var(--accent-soft); color: var(--accent);
+    border-radius: var(--radius-s); padding: 12px 16px;
+    font-size: 14.5px; font-weight: 600;
+    display: flex; align-items: center; gap: 8px;
+    animation: popIn 0.4s ease;
+}
+.settle-footer {
+    display: flex; justify-content: space-between; align-items: center;
+    flex-wrap: wrap; gap: 12px;
+}
+.rates-note { font-size: 12.5px; color: var(--muted); }
+.rates-note .bi { margin-right: 6px; }
+
+/* --- Toasts --- */
+.toast-container-ledger {
+    position: fixed; right: 16px; bottom: 16px; z-index: 100;
+    display: flex; flex-direction: column; gap: 8px;
+}
+.toast-ledger {
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: var(--radius-s); padding: 10px 14px;
+    font-size: 13.5px; color: var(--ink);
+    display: flex; align-items: center; gap: 8px;
+    animation: fadeUp 0.25s ease;
+}
+.toast-ledger .bi { color: var(--neg); }
+
+/* --- Footer --- */
+.site-footer {
+    margin-top: 48px; padding: 20px 24px; text-align: center;
+    border-top: 1px solid var(--line);
+}
+.site-footer small { color: var(--muted); font-size: 12.5px; }
+
+/* --- Responsive --- */
+@media (min-width: 700px) {
+    .only-mobile { display: none !important; }
+}
+@media (max-width: 699.98px) {
+    .only-desktop { display: none !important; }
+    .tabs-ledger { display: none; }
+    .tabbar-mobile { display: flex; }
+    body { padding-bottom: calc(72px + env(safe-area-inset-bottom)); }
+    .share-pill__url { display: none; }
+    .toast-container-ledger { bottom: calc(84px + env(safe-area-inset-bottom)); }
+    /* Prevent iOS focus zoom */
+    .input-ledger, .select-ledger, .chip-input { font-size: 16px; }
+    .input-title { font-size: 20px; }
 }
 
-.money-icon:nth-of-type(2) {
-    animation: flyMoney 3s infinite;
-    animation-delay: 0s;
-}
-
-.money-icon:nth-of-type(3) {
-    animation: flyMoney 3s infinite;
-    animation-delay: 0.5s;
-}
-
+/* --- Animations --- */
 @keyframes shake {
     0%, 100% { transform: rotate(0deg); }
     25% { transform: rotate(-5deg); }
     75% { transform: rotate(5deg); }
 }
-
-@keyframes flyMoney {
-    0% {
-        opacity: 0;
-        left: 0;
-        top: 50%;
-    }
-    25% {
-        opacity: 1;
-        left: 100%;
-        top: 0;
-    }
-    50% {
-        opacity: 0;
-        left: 150%;
-        top: -50%;
-    }
-    100% {
-        opacity: 0;
-        left: 150%;
-        top: -50%;
-    }
+@keyframes fadeUp {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
 }
+@keyframes popIn {
+    0% { opacity: 0; transform: scale(0.9); }
+    70% { transform: scale(1.02); }
+    100% { opacity: 1; transform: scale(1); }
+}
+.anim-fade-up { animation: fadeUp 0.25s ease; }
+.anim-pop-in { animation: popIn 0.4s ease; }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -112,7 +112,7 @@ button:focus-visible, a:focus-visible {
 /* --- Header --- */
 .site-header { border-bottom: 1px solid var(--line); background: var(--bg); }
 .header-inner {
-    padding-top: 16px; padding-bottom: 16px;
+    padding-top: 16px; padding-bottom: 4px;
     display: flex; align-items: center; justify-content: space-between; gap: 16px;
 }
 .brand { display: flex; align-items: center; gap: 10px; margin-top: 9px; }
@@ -141,7 +141,7 @@ button:focus-visible, a:focus-visible {
 }
 .header-note {
     font-size: 12px; color: var(--muted);
-    text-align: right; padding-bottom: 12px; margin-top: -6px;
+    text-align: right; padding-bottom: 12px;
 }
 .copy-btn {
     border: none; background: transparent; padding: 0;
@@ -487,7 +487,10 @@ button:focus-visible, a:focus-visible {
     .tabs-ledger { display: none; }
     .tabbar-mobile { display: flex; }
     body { padding-bottom: calc(72px + env(safe-area-inset-bottom)); }
-    .share-pill__url { display: none; }
+    .header-inner { flex-wrap: wrap; }
+    .header-actions { width: 100%; }
+    .share-pill { flex: 1; min-width: 0; }
+    .share-pill__url { flex: 1; }
     /* Prevent iOS focus zoom */
     .input-ledger, .select-ledger, .chip-input { font-size: 16px; }
     .input-title { font-size: 20px; }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,42 +1,79 @@
+// ===== State =====
 let participants = [];
 let savedExpenses = [];
 let groupId = window.location.pathname.split('/g/').pop();
 const exchangeRateCache = new Map();
 
+let activeTab = 'add';
+let editingExpenseId = null;
+let settled = false;
+const paidTransfers = new Set();
+let addingPerson = false;
+let copyTimer = null;
+let countUpRaf = null;
+let totalsRunId = 0;
+
+// The design lists all amounts in USD; the backend still requires a
+// displayCurrency on every expense, so it is fixed here.
+const DISPLAY_CURRENCY = 'USD';
+
+const CURRENCIES = [
+    { code: 'USD', name: 'US Dollar' },
+    { code: 'EUR', name: 'Euro' },
+    { code: 'JPY', name: 'Japanese Yen' },
+    { code: 'GBP', name: 'British Pound' },
+    { code: 'CNY', name: 'Chinese Yuan' },
+    { code: 'AUD', name: 'Australian Dollar' },
+    { code: 'CAD', name: 'Canadian Dollar' },
+    { code: 'CHF', name: 'Swiss Franc' },
+    { code: 'HKD', name: 'Hong Kong Dollar' },
+    { code: 'SGD', name: 'Singapore Dollar' },
+    { code: 'SEK', name: 'Swedish Krona' },
+    { code: 'KRW', name: 'South Korean Won' },
+    { code: 'INR', name: 'Indian Rupee' },
+    { code: 'BRL', name: 'Brazilian Real' },
+    { code: 'RUB', name: 'Russian Ruble' },
+    { code: 'ZAR', name: 'South African Rand' },
+    { code: 'MXN', name: 'Mexican Peso' },
+    { code: 'IDR', name: 'Indonesian Rupiah' },
+    { code: 'TRY', name: 'Turkish Lira' },
+    { code: 'SAR', name: 'Saudi Riyal' }
+];
+
+// Settlement data kept for rendering and PDF export
+window.settlementData = {
+    settlements: {},
+    transfers: [],
+    balances: [],
+    baseCurrency: DISPLAY_CURRENCY,
+    exchangeRateInfo: null
+};
+
+// ===== Init =====
 document.addEventListener('DOMContentLoaded', () => {
-    // Load initial data
+    initTheme();
+    initEvents();
+    populateBaseCurrencySelect();
+
     fetch(`/api/g/${groupId}`)
         .then(response => response.json())
         .then(data => {
-            if (data.participants) {
-                participants = data.participants;
-                updateParticipantList();
-                updateAllParticipantSelects();
-            }
-            if (data.expenses) {
-                savedExpenses = data.expenses;
-                updateExpenseTable();
-            }
+            if (data.participants) participants = data.participants;
+            if (data.expenses) savedExpenses = data.expenses;
         })
-        .catch(error => console.error('Error loading expenses:', error));
-        
-    // Add window resize listener to update the view based on screen size
-    window.addEventListener('resize', debounce(function() {
-        if (document.querySelector('#view-expenses.active, #view-expenses.show')) {
+        .catch(error => console.error('Error loading group:', error))
+        .finally(() => {
+            renderPeople();
+            resetExpenseForm();
             updateExpenseTable();
-        }
-    }, 250));
-    
-    // Add listener for tab changes to ensure mobile view switches correctly
-    document.getElementById('view-expenses-tab').addEventListener('shown.bs.tab', function() {
-        updateExpenseTable();
-    });
+            updateEmptyStates();
+            renderTabState();
+        });
 });
 
-// Debounce function to prevent excessive calls during window resize
 function debounce(func, wait) {
     let timeout;
-    return function() {
+    return function () {
         const context = this;
         const args = arguments;
         clearTimeout(timeout);
@@ -44,6 +81,261 @@ function debounce(func, wait) {
             func.apply(context, args);
         }, wait);
     };
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function formatNumber(amount) {
+    return amount.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+}
+
+function formatMoney(amount, currency) {
+    return currency === 'USD' ? `$${formatNumber(amount)}` : `${currency} ${formatNumber(amount)}`;
+}
+
+// ===== Event wiring =====
+function initEvents() {
+    document.body.addEventListener('click', event => {
+        const target = event.target.closest('[data-action]');
+        if (!target) return;
+        switch (target.dataset.action) {
+            case 'toggle-theme': toggleTheme(); break;
+            case 'copy-link': copyGroupLink(); break;
+            case 'switch-tab': switchTab(target.dataset.tab); break;
+            case 'start-add-person': startPersonAdd(); break;
+            case 'remove-person': removeParticipant(target.dataset.name); break;
+            case 'add-payer': addPayerRow(); break;
+            case 'add-split': addSplitRow(); break;
+            case 'split-evenly': splitEvenly(); break;
+            case 'remove-row': removeEntryRow(target); break;
+            case 'save-expense': saveExpense(); break;
+            case 'cancel-edit': resetExpenseForm(); break;
+            case 'edit-expense': editExpense(Number(target.dataset.id)); break;
+            case 'delete-expense': deleteExpense(Number(target.dataset.id)); break;
+            case 'toggle-transfer': toggleTransferPaid(Number(target.dataset.index)); break;
+            case 'calculate': calculateSettlement(); break;
+            case 'export-pdf': exportToPDF(); break;
+        }
+    });
+
+    document.body.addEventListener('keydown', event => {
+        if ((event.key === 'Enter' || event.key === ' ') && event.target.classList.contains('transfer-row')) {
+            event.preventDefault();
+            toggleTransferPaid(Number(event.target.dataset.index));
+        }
+    });
+
+    const personInput = document.getElementById('personInput');
+    personInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') commitPersonAdd();
+        if (event.key === 'Escape') cancelPersonAdd();
+    });
+    personInput.addEventListener('blur', commitPersonAdd);
+
+    const form = document.getElementById('expenseForm');
+    const debouncedTotals = debounce(recomputeTotalsIndicator, 300);
+    form.addEventListener('input', event => {
+        if (event.target.classList.contains('amount-input')) {
+            clearEntryValidation(event.target.closest('.entry-row'));
+            debouncedTotals();
+        }
+    });
+    form.addEventListener('change', event => {
+        if (event.target.classList.contains('person-select')) {
+            refreshFormSelects();
+            return;
+        }
+        if (event.target.classList.contains('amount-input') ||
+            event.target.classList.contains('currency-select')) {
+            recomputeTotalsIndicator();
+        }
+    });
+}
+
+// ===== Theme =====
+function currentTheme() {
+    const attr = document.documentElement.getAttribute('data-theme');
+    if (attr === 'dark' || attr === 'light') return attr;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function updateThemeIcon() {
+    document.getElementById('themeToggleIcon').className =
+        currentTheme() === 'dark' ? 'bi bi-sun' : 'bi bi-moon';
+}
+
+function toggleTheme() {
+    const next = currentTheme() === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try {
+        localStorage.setItem('bw-theme', next);
+    } catch (e) { /* storage unavailable */ }
+    updateThemeIcon();
+}
+
+function initTheme() {
+    updateThemeIcon();
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateThemeIcon);
+}
+
+// ===== Copy link =====
+async function copyGroupLink() {
+    const url = window.location.href;
+    let copied = false;
+
+    if (navigator.clipboard && window.isSecureContext) {
+        try {
+            await navigator.clipboard.writeText(url);
+            copied = true;
+        } catch (e) { /* fall through */ }
+    }
+    if (!copied) {
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            copied = document.execCommand('copy');
+        } catch (e) { /* unsupported */ }
+        textarea.remove();
+    }
+
+    if (copied) {
+        const btn = document.getElementById('copyLinkBtn');
+        btn.textContent = 'Copied ✓';
+        clearTimeout(copyTimer);
+        copyTimer = setTimeout(() => { btn.textContent = 'Copy'; }, 1600);
+    } else {
+        showErrorToast('Could not copy the link.');
+    }
+}
+
+// ===== Tabs =====
+function switchTab(tab) {
+    activeTab = tab;
+
+    document.querySelectorAll('#desktopTabs [data-tab]').forEach(btn => {
+        const isActive = btn.dataset.tab === tab;
+        btn.classList.toggle('active', isActive);
+        btn.setAttribute('aria-selected', String(isActive));
+    });
+    document.querySelectorAll('#mobileTabbar [data-tab]').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.tab === tab);
+    });
+    document.getElementById('tabAddIconMobile').className =
+        tab === 'add' ? 'bi bi-plus-circle-fill' : 'bi bi-plus-circle';
+
+    ['add', 'view', 'settle'].forEach(name => {
+        const pane = document.getElementById(`pane-${name}`);
+        if (name === tab) {
+            pane.hidden = false;
+            pane.classList.remove('anim-fade-up');
+            void pane.offsetWidth; // restart the fadeUp animation
+            pane.classList.add('anim-fade-up');
+        } else {
+            pane.hidden = true;
+        }
+    });
+}
+
+function renderTabState() {
+    const label = editingExpenseId !== null ? 'Edit' : 'Add';
+    document.getElementById('tabAddLabel').textContent = label;
+    document.getElementById('tabAddLabelMobile').textContent = label;
+    const badge = document.getElementById('expenseCountBadge');
+    badge.textContent = savedExpenses.length;
+    badge.hidden = false;
+}
+
+// ===== People =====
+function renderPeople() {
+    const row = document.getElementById('peopleRow');
+    const input = document.getElementById('personInput');
+    const ghost = document.getElementById('addPersonChip');
+
+    row.querySelectorAll('.chip').forEach(chip => chip.remove());
+    participants.forEach(name => {
+        const chip = document.createElement('span');
+        chip.className = 'chip';
+        chip.innerHTML = `${escapeHtml(name)}<button type="button" class="chip__x" data-action="remove-person" data-name="${escapeHtml(name)}" aria-label="Remove ${escapeHtml(name)}"><i class="bi bi-x"></i></button>`;
+        row.insertBefore(chip, input);
+    });
+
+    input.hidden = !addingPerson;
+    ghost.hidden = addingPerson;
+}
+
+function startPersonAdd() {
+    addingPerson = true;
+    const input = document.getElementById('personInput');
+    input.value = '';
+    renderPeople();
+    input.focus();
+}
+
+function commitPersonAdd() {
+    if (!addingPerson) return;
+    addingPerson = false;
+
+    const input = document.getElementById('personInput');
+    const name = input.value.trim();
+    input.value = '';
+
+    if (name && !participants.includes(name)) {
+        participants.push(name);
+        saveParticipantsToBackend().catch(error => {
+            console.error('Error saving participants:', error);
+            showErrorToast('Error saving people. Please try again.');
+        });
+        onParticipantsChanged();
+    } else {
+        renderPeople();
+    }
+}
+
+function cancelPersonAdd() {
+    addingPerson = false;
+    document.getElementById('personInput').value = '';
+    renderPeople();
+}
+
+function removeParticipant(name) {
+    participants = participants.filter(p => p !== name);
+    saveParticipantsToBackend().catch(error => {
+        console.error('Error saving participants:', error);
+        showErrorToast('Error saving people. Please try again.');
+    });
+    onParticipantsChanged();
+}
+
+function onParticipantsChanged() {
+    renderPeople();
+    refreshFormSelects();
+    if (isFormPristine()) {
+        resetExpenseForm();
+    }
+    invalidateSettlement();
+    updateEmptyStates();
+}
+
+// True while the expense form is untouched, so people changes can re-seed it.
+function isFormPristine() {
+    if (editingExpenseId !== null) return false;
+    if (document.getElementById('expenseDescription').value.trim() !== '') return false;
+    return Array.from(document.querySelectorAll('#expenseForm .amount-input'))
+        .every(input => input.value.trim() === '');
 }
 
 async function saveParticipantsToBackend() {
@@ -62,420 +354,43 @@ async function saveParticipantsToBackend() {
     }
 }
 
-async function exportGroupData() {
-    try {
-        const response = await fetch(`/api/g/${groupId}/export`);
-        if (!response.ok) {
-            throw new Error('Failed to export data');
-        }
+// ===== Empty states =====
+function updateEmptyStates() {
+    const hasPeople = participants.length > 0;
+    const hasExpenses = savedExpenses.length > 0;
 
-        const blob = await response.blob();
-        const url = window.URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `expense_group_${groupId}.json`;
-        document.body.appendChild(a);
-        a.click();
-        window.URL.revokeObjectURL(url);
-        document.body.removeChild(a);
+    document.getElementById('addEmptyState').hidden = hasPeople;
+    document.getElementById('expenseForm').hidden = !hasPeople;
+    document.getElementById('addHelperText').hidden = !hasPeople;
 
-        const toastDiv = document.createElement('div');
-        toastDiv.innerHTML = `
-            <div class="toast-container position-fixed bottom-0 end-0 p-3">
-                <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-                    <div class="toast-header">
-                        <strong class="me-auto">Export Successful!</strong>
-                        <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-                    </div>
-                    <div class="toast-body">
-                        Your expense data has been exported successfully.
-                    </div>
-                </div>
-            </div>`;
-        document.body.appendChild(toastDiv);
+    document.getElementById('viewEmptyState').hidden = hasExpenses;
+    document.getElementById('expenseTableWrap').hidden = !hasExpenses;
+    document.getElementById('expenseCardsWrap').hidden = !hasExpenses;
 
-        const toast = new bootstrap.Toast(toastDiv.querySelector('.toast'));
-        toast.show();
-    } catch (error) {
-        console.error('Error exporting data:', error);
-        alert('Error exporting data. Please try again.');
+    document.getElementById('settleEmptyState').hidden = hasExpenses;
+    document.getElementById('settleControls').hidden = !hasExpenses;
+    document.getElementById('settleHint').hidden = !hasExpenses || settled;
+    document.getElementById('settlementResults').hidden = !settled;
+}
+
+// ===== Toasts =====
+function showErrorToast(message) {
+    let container = document.querySelector('.toast-container-ledger');
+    if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container-ledger';
+        container.setAttribute('aria-live', 'polite');
+        document.body.appendChild(container);
     }
+    const toast = document.createElement('div');
+    toast.className = 'toast-ledger';
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `<i class="bi bi-exclamation-circle"></i>${escapeHtml(message)}`;
+    container.appendChild(toast);
+    setTimeout(() => toast.remove(), 3500);
 }
 
-async function exportToPDF() {
-    // First make sure we have the settlement data
-    if (!document.querySelector('#settlementResults .card')) {
-        alert('Please calculate the settlement first before exporting to PDF.');
-        return;
-    }
-    
-    // Store current settlement data for use in PDF export
-    const pdfData = {
-        settlementsData: null,
-        baseCurrency: document.getElementById('baseCurrency').value
-    };
-    
-    // Get the settlement data from the DOM
-    try {
-        const summaryTable = document.querySelector('#settlementResults .table');
-        if (summaryTable) {
-            const rows = Array.from(summaryTable.querySelectorAll('tbody tr'));
-            pdfData.settlementsData = {};
-            
-            rows.forEach(row => {
-                const cells = Array.from(row.querySelectorAll('td'));
-                const person = cells[0].textContent.trim();
-                const balanceText = cells[3].textContent.trim();
-                const isPositive = cells[3].classList.contains('text-success');
-                const amountText = balanceText.replace(/[^0-9.,]/g, '');
-                const amount = parseFloat(amountText) * (isPositive ? 1 : -1);
-                pdfData.settlementsData[person] = amount;
-            });
-        }
-    } catch (error) {
-        console.error('Error extracting settlement data:', error);
-    }
-
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-    let yPos = 20;
-
-    // Title and basic info
-    doc.setFontSize(24);
-    doc.setTextColor(44, 62, 80);
-    doc.text('Brokewise', 20, yPos);
-    yPos += 10;
-
-    doc.setFontSize(16);
-    doc.text('Expense Report', 20, yPos);
-    yPos += 10;
-
-    doc.setFontSize(10);
-    doc.setTextColor(100, 100, 100);
-    doc.text(`Generated on: ${new Date().toLocaleDateString()}`, 20, yPos);
-    yPos += 15;
-
-    // Participants section
-    doc.setFontSize(14);
-    doc.setTextColor(44, 62, 80);
-    doc.text('Participants', 20, yPos);
-    yPos += 10;
-
-    doc.setFontSize(10);
-    doc.setTextColor(0, 0, 0);
-    participants.forEach(participant => {
-        doc.text(`• ${participant}`, 25, yPos);
-        yPos += 6;
-    });
-    yPos += 10;
-
-    // Expenses section
-    doc.setFontSize(14);
-    doc.setTextColor(44, 62, 80);
-    doc.text('Expenses', 20, yPos);
-    yPos += 10;
-
-    const headers = ['Description', 'Paid By', 'Amount', 'Split Between'];
-    const colWidths = [50, 45, 30, 45];
-    doc.setFontSize(9);
-    doc.setTextColor(0, 0, 0);
-
-    doc.setFillColor(240, 240, 240);
-    doc.rect(20, yPos - 5, 170, 8, 'F');
-    headers.forEach((header, i) => {
-        let xPos = 20;
-        for (let j = 0; j < i; j++) xPos += colWidths[j];
-        doc.text(header, xPos + 2, yPos);
-    });
-    yPos += 8;
-
-    doc.setFontSize(8);
-    savedExpenses.forEach(expense => {
-        if (yPos > 270) {
-            doc.addPage();
-            yPos = 20;
-        }
-
-        const payers = expense.payers.map(p =>
-            `${p.person} (${p.currency} ${addCommasToNumber(p.amount.toFixed(2))})`
-        ).join('\n');
-
-        const splits = expense.splits.map(s =>
-            `${s.person} (${s.currency} ${addCommasToNumber(s.amount.toFixed(2))})`
-        ).join('\n');
-
-        // Calculate total and format with commas and two decimal places
-        const totalAmount = expense.payers.reduce((sum, p) => sum + p.amount, 0);
-        const displayAmount = `${expense.displayCurrency} ${addCommasToNumber(totalAmount.toFixed(2))}`;
-
-        let xPos = 20;
-        doc.text(expense.description, xPos + 2, yPos, { maxWidth: colWidths[0] - 4 });
-        xPos += colWidths[0];
-
-        doc.text(payers, xPos + 2, yPos, { maxWidth: colWidths[1] - 4 });
-        xPos += colWidths[1];
-
-        doc.text(displayAmount, xPos + 2, yPos);
-        xPos += colWidths[2];
-
-        doc.text(splits, xPos + 2, yPos, { maxWidth: colWidths[3] - 4 });
-
-        const lineHeight = Math.max(
-            doc.splitTextToSize(expense.description, colWidths[0] - 4).length,
-            doc.splitTextToSize(payers, colWidths[1] - 4).length,
-            doc.splitTextToSize(splits, colWidths[3] - 4).length
-        ) * 4;
-
-        yPos += lineHeight + 4;
-    });
-
-    // Add Settlement Summary on a new page
-    doc.addPage();
-    yPos = 20;
-
-    doc.setFontSize(14);
-    doc.setTextColor(44, 62, 80);
-    doc.text('Settlement Summary', 20, yPos);
-    yPos += 15;
-
-    // Add Summary Table
-    const summaryTable = document.querySelector('#settlementResults .table');
-    if (summaryTable) {
-        const headers = Array.from(summaryTable.querySelectorAll('th')).map(th => th.textContent);
-        const rows = Array.from(summaryTable.querySelectorAll('tbody tr')).map(tr =>
-            Array.from(tr.querySelectorAll('td')).map(td => td.textContent)
-        );
-
-        // Draw table headers
-        doc.setFontSize(10);
-        doc.setFillColor(240, 240, 240);
-        doc.rect(20, yPos - 5, 170, 8, 'F');
-
-        const colWidths = [40, 40, 40, 50];
-        headers.forEach((header, i) => {
-            let xPos = 20;
-            for (let j = 0; j < i; j++) xPos += colWidths[j];
-            doc.text(header, xPos + 2, yPos);
-        });
-        yPos += 10;
-
-        // Draw table rows with proper formatting for the summary
-        doc.setFontSize(9);
-        
-        rows.forEach(row => {
-            let xPos = 20;
-            
-            // First process each cell to extract the right data for display
-            const processedRow = row.map((cell, i) => {
-                let cellText = cell.trim();
-                
-                // For the Net Balance column (index 3), format with proper sign
-                if (i === 3) {
-                    // Check if this is a negative value by examining the cell's class in the original table
-                    const rowIndex = rows.indexOf(row);
-                    const tableRow = summaryTable.querySelectorAll('tbody tr')[rowIndex];
-                    const netBalanceCell = tableRow.querySelectorAll('td')[3];
-                    const isNegative = netBalanceCell.classList.contains('text-danger');
-                    
-                    // Extract just the currency code and numeric amount
-                    const currencyMatch = cellText.match(/[A-Z]{3}/);
-                    const amountMatch = cellText.match(/[\d,]+\.\d{2}/);
-                    
-                    if (currencyMatch && amountMatch) {
-                        const currency = currencyMatch[0];
-                        const amount = amountMatch[0];
-                        
-                        // Format with appropriate sign
-                        if (isNegative) {
-                            return `-${currency} ${amount}`;
-                        } else {
-                            return `+${currency} ${amount}`;
-                        }
-                    }
-                }
-                
-                return cellText;
-            });
-            
-            // Now print each processed cell
-            processedRow.forEach((cellText, i) => {
-                doc.text(cellText, xPos + 2, yPos);
-                xPos += colWidths[i];
-            });
-            
-            yPos += 7;
-        });
-        yPos += 10;
-    }
-
-    // Settlement Results and Recommended Transfers sections have been removed as requested
-
-    doc.save('brokewise-report.pdf');
-}
-
-function addParticipant() {
-    const input = document.getElementById('participantInput');
-    const name = input.value.trim();
-
-    if (name && !participants.includes(name)) {
-        participants.push(name);
-        input.value = '';
-        updateParticipantList();
-        updateAllParticipantSelects();
-        saveParticipantsToBackend().catch(error => console.error('Error saving participants:', error));
-    }
-}
-
-function removeParticipant(name) {
-    participants = participants.filter(p => p !== name);
-    updateParticipantList();
-    updateAllParticipantSelects();
-    saveParticipantsToBackend().catch(error => console.error('Error saving participants:', error));
-}
-
-function updateParticipantList() {
-    const list = document.getElementById('participantList');
-    list.innerHTML = participants.map(name =>
-        `<span class="badge bg-secondary participant-badge">
-            ${name}
-            <i class="bi bi-x-circle" onclick="removeParticipant('${name}')"></i>
-         </span>`
-    ).join('');
-}
-
-function updateAllParticipantSelects() {
-    document.querySelectorAll('.expense-entry').forEach(expenseEntry => {
-        const payerSelects = expenseEntry.querySelectorAll('.payer-entry .payer-select');
-        const selectedPayers = Array.from(payerSelects).map(select => select.value);
-
-        payerSelects.forEach(select => {
-            const currentValue = select.value;
-            select.innerHTML = participants
-                .filter(p => p === currentValue || !selectedPayers.includes(p))
-                .map(p => `<option value="${p}">${p}</option>`)
-                .join('');
-            select.value = currentValue;
-        });
-
-        const splitSelects = expenseEntry.querySelectorAll('.split-entry .split-select');
-        const selectedSplits = Array.from(splitSelects).map(select => select.value);
-
-        splitSelects.forEach(select => {
-            const currentValue = select.value;
-            select.innerHTML = participants
-                .filter(p => p === currentValue || !selectedSplits.includes(p))
-                .map(p => `<option value="${p}">${p}</option>`)
-                .join('');
-            select.value = currentValue;
-        });
-    });
-}
-
-function addExpenseRow() {
-    // Check if there are any participants
-    if (participants.length === 0) {
-        alert('No participants have been added. Please add participants first before creating an expense.');
-        return;
-    }
-
-    const template = document.getElementById('expenseTemplate');
-    const expenseList = document.getElementById('expenseList');
-    const clone = template.content.cloneNode(true);
-
-    const displayCurrencySelect = clone.querySelector('.display-currency-select');
-    displayCurrencySelect.innerHTML = currencyOptions;
-
-    expenseList.appendChild(clone);
-
-    const expenseEntry = expenseList.lastElementChild;
-    addPayer(expenseEntry.querySelector('.payers-list').nextElementSibling);
-    addSplit(expenseEntry.querySelector('.splits-list').nextElementSibling);
-    updateAllParticipantSelects();
-}
-
-function addPayer(btn) {
-    const template = document.getElementById('payerTemplate');
-    const payersList = btn.previousElementSibling;
-    const clone = template.content.cloneNode(true);
-
-    const currentPayers = Array.from(payersList.querySelectorAll('.payer-select')).map(select => select.value);
-
-    const select = clone.querySelector('.payer-select');
-    select.innerHTML = participants
-        .filter(p => !currentPayers.includes(p))
-        .map(p => `<option value="${p}">${p}</option>`)
-        .join('');
-
-    if (select.options.length > 0) {
-        const amountInput = clone.querySelector('.amount-input');
-        payersList.appendChild(clone);
-        updateAllParticipantSelects();
-        updateTotals(select);
-        amountInput.focus();
-    } else {
-        // More accurate message
-        if (participants.length === 0) {
-            alert('No participants have been added to the group');
-        } else {
-            alert('All participants have been added as payers');
-        }
-    }
-}
-
-function addSplit(btn) {
-    const template = document.getElementById('splitTemplate');
-    const splitsList = btn.previousElementSibling;
-    const clone = template.content.cloneNode(true);
-
-    const currentSplits = Array.from(splitsList.querySelectorAll('.split-select')).map(select => select.value);
-
-    const select = clone.querySelector('.split-select');
-    select.innerHTML = participants
-        .filter(p => !currentSplits.includes(p))
-        .map(p => `<option value="${p}">${p}</option>`)
-        .join('');
-
-    if (select.options.length > 0) {
-        splitsList.appendChild(clone);
-        updateAllParticipantSelects();
-        updateTotals(select);
-    } else {
-        // More accurate message
-        if (participants.length === 0) {
-            alert('No participants have been added to the group');
-        } else {
-            alert('All participants have been added to the split');
-        }
-    }
-}
-
-function removePayer(btn) {
-    const payerEntry = btn.closest('.payer-entry');
-    const payersList = payerEntry.parentElement;
-    payerEntry.remove();
-    updateTotals(payersList);
-
-    if (payersList.children.length === 0) {
-        addPayer(payersList.nextElementSibling);
-    }
-}
-
-function removeSplit(btn) {
-    const splitEntry = btn.closest('.split-entry');
-    const splitsList = splitEntry.parentElement;
-    splitEntry.remove();
-    updateTotals(splitsList);
-
-    if (splitsList.children.length === 0) {
-        addSplit(splitsList.nextElementSibling);
-    }
-}
-
-function removeExpense(btn) {
-    const expenseEntry = btn.closest('.expense-entry');
-    expenseEntry.remove();
-}
-
+// ===== Backend calls =====
 async function getExchangeRate(fromCurrency, toCurrency) {
     if (fromCurrency === toCurrency) {
         return 1.0;
@@ -535,6 +450,7 @@ async function deleteExpenseFromBackend(id) {
     }
 }
 
+// ===== Amount helpers =====
 function parseAmountInput(input) {
     const amount = parseFloat(input.value);
     return Number.isFinite(amount) ? amount : null;
@@ -553,10 +469,7 @@ async function getConvertedCents(entry, displayCurrency) {
 }
 
 function formatCents(cents) {
-    return (cents / 100).toLocaleString('en-US', {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2
-    });
+    return formatNumber(cents / 100);
 }
 
 function amountsMatchInCents(totalPaidCents, totalSplitCents) {
@@ -565,19 +478,12 @@ function amountsMatchInCents(totalPaidCents, totalSplitCents) {
 
 function clearEntryValidation(entry) {
     if (!entry) return;
-
-    entry.classList.remove('invalid-entry');
-    const amountInput = entry.querySelector('.amount-input');
-    if (amountInput) {
-        amountInput.classList.remove('is-invalid');
-    }
+    entry.classList.remove('is-invalid');
 }
 
 function markEntryInvalid(entry) {
-    entry.classList.add('invalid-entry');
-    const amountInput = entry.querySelector('.amount-input');
-    amountInput.classList.add('is-invalid');
-    return amountInput;
+    entry.classList.add('is-invalid');
+    return entry.querySelector('.amount-input');
 }
 
 function focusInvalidInput(input) {
@@ -585,117 +491,240 @@ function focusInvalidInput(input) {
     input.focus();
 }
 
-async function updateTotals(element) {
-    const expenseEntry = element.closest('.expense-entry');
-    const saveBtn = expenseEntry.querySelector('.btn-success');
-    saveBtn.disabled = true;
+// ===== Expense form =====
+function createEntryRow(prefill = {}) {
+    const template = document.getElementById('entryRowTemplate');
+    const row = template.content.cloneNode(true).firstElementChild;
 
-    const displayCurrency = expenseEntry.querySelector('.display-currency-select').value;
-    let totalPaidCents = 0;
-    let totalSplitCents = 0;
+    const personSelect = row.querySelector('.person-select');
+    personSelect.innerHTML = participants
+        .map(p => `<option value="${escapeHtml(p)}">${escapeHtml(p)}</option>`)
+        .join('');
+    if (prefill.person) personSelect.value = prefill.person;
 
-    for (const payerEntry of expenseEntry.querySelectorAll('.payer-entry')) {
-        totalPaidCents += await getConvertedCents(payerEntry, displayCurrency);
+    const currencySelect = row.querySelector('.currency-select');
+    currencySelect.innerHTML = CURRENCIES
+        .map(c => `<option value="${c.code}">${c.code}</option>`)
+        .join('');
+    currencySelect.value = prefill.currency || DISPLAY_CURRENCY;
+
+    if (prefill.amount !== undefined && prefill.amount !== null && prefill.amount !== '') {
+        row.querySelector('.amount-input').value = prefill.amount;
     }
-
-    for (const splitEntry of expenseEntry.querySelectorAll('.split-entry')) {
-        totalSplitCents += await getConvertedCents(splitEntry, displayCurrency);
-    }
-
-    expenseEntry.querySelector('.total-paid').textContent =
-        `${displayCurrency} ${formatCents(totalPaidCents)}`;
-    expenseEntry.querySelector('.total-split').textContent =
-        `${displayCurrency} ${formatCents(totalSplitCents)}`;
-
-    const warning = expenseEntry.querySelector('.amounts-mismatch-warning');
-    const amountsMatch = amountsMatchInCents(totalPaidCents, totalSplitCents);
-    warning.style.display = amountsMatch ? 'none' : 'block';
-    saveBtn.disabled = !amountsMatch;
+    return row;
 }
 
-async function saveExpense(btn) {
-    const expenseEntry = btn.closest('.expense-entry');
-    const description = expenseEntry.querySelector('input[type="text"]').value;
-    const displayCurrency = expenseEntry.querySelector('.display-currency-select').value;
-    const invalidEntries = expenseEntry.querySelectorAll('.invalid-entry');
-    invalidEntries.forEach(clearEntryValidation);
+function addEntryRow(listId, prefill) {
+    const list = document.getElementById(listId);
+    if (!prefill) {
+        const chosen = Array.from(list.querySelectorAll('.person-select')).map(s => s.value);
+        const available = participants.filter(p => !chosen.includes(p));
+        if (available.length === 0) {
+            showErrorToast(participants.length === 0
+                ? 'Add people to the group first.'
+                : (listId === 'payersList' ? 'Everyone is already a payer.' : 'Everyone is already in the split.'));
+            return null;
+        }
+        prefill = { person: available[0] };
+    }
+    const row = createEntryRow(prefill);
+    list.appendChild(row);
+    return row;
+}
 
-    // Validate description
+function addPayerRow() {
+    const row = addEntryRow('payersList');
+    if (row) {
+        refreshFormSelects();
+        row.querySelector('.amount-input').focus();
+        recomputeTotalsIndicator();
+    }
+}
+
+function addSplitRow() {
+    const row = addEntryRow('splitsList');
+    if (row) {
+        refreshFormSelects();
+        recomputeTotalsIndicator();
+    }
+}
+
+function removeEntryRow(btn) {
+    const row = btn.closest('.entry-row');
+    const list = row.parentElement;
+    row.remove();
+    if (list.children.length === 0) {
+        if (list.id === 'payersList') addPayerRow();
+        else addSplitRow();
+    }
+    refreshFormSelects();
+    recomputeTotalsIndicator();
+}
+
+function refreshFormSelects() {
+    ['payersList', 'splitsList'].forEach(listId => {
+        const selects = document.getElementById(listId).querySelectorAll('.person-select');
+        const chosen = Array.from(selects).map(s => s.value);
+        selects.forEach(select => {
+            const current = select.value;
+            select.innerHTML = participants
+                .filter(p => p === current || !chosen.includes(p))
+                .map(p => `<option value="${escapeHtml(p)}">${escapeHtml(p)}</option>`)
+                .join('');
+            select.value = current;
+        });
+    });
+}
+
+function resetExpenseForm() {
+    editingExpenseId = null;
+    document.getElementById('expenseDescription').value = '';
+
+    const payersList = document.getElementById('payersList');
+    const splitsList = document.getElementById('splitsList');
+    payersList.innerHTML = '';
+    splitsList.innerHTML = '';
+    if (participants.length > 0) {
+        payersList.appendChild(createEntryRow({ person: participants[0] }));
+        participants.forEach(p => splitsList.appendChild(createEntryRow({ person: p })));
+        refreshFormSelects();
+    }
+
+    setEditingUI(false);
+    recomputeTotalsIndicator();
+}
+
+function setEditingUI(isEditing) {
+    document.getElementById('saveExpenseBtn').textContent = isEditing ? 'Update expense' : 'Save expense';
+    document.getElementById('cancelEditBtn').hidden = !isEditing;
+    renderTabState();
+}
+
+async function recomputeTotalsIndicator() {
+    const runId = ++totalsRunId;
+    let totalPaidCents = 0;
+    let totalSplitCents = 0;
+    let hasAmounts = false;
+
+    for (const row of document.querySelectorAll('#payersList .entry-row')) {
+        if (row.querySelector('.amount-input').value.trim() !== '') hasAmounts = true;
+        totalPaidCents += await getConvertedCents(row, DISPLAY_CURRENCY);
+    }
+    for (const row of document.querySelectorAll('#splitsList .entry-row')) {
+        if (row.querySelector('.amount-input').value.trim() !== '') hasAmounts = true;
+        totalSplitCents += await getConvertedCents(row, DISPLAY_CURRENCY);
+    }
+
+    if (runId !== totalsRunId) return; // a newer recompute superseded this one
+
+    const indicator = document.getElementById('totalsIndicator');
+    const icon = document.getElementById('totalsIcon');
+    const text = document.getElementById('totalsText');
+    const saveBtn = document.getElementById('saveExpenseBtn');
+    const matched = totalPaidCents > 0 && amountsMatchInCents(totalPaidCents, totalSplitCents);
+
+    if (!hasAmounts) {
+        indicator.classList.remove('is-matched');
+        icon.className = 'bi bi-circle';
+        text.textContent = 'Enter amounts';
+        saveBtn.classList.add('is-disabled');
+    } else if (matched) {
+        indicator.classList.add('is-matched');
+        icon.className = 'bi bi-check-circle-fill';
+        text.textContent = `Totals match · $${formatCents(totalPaidCents)}`;
+        saveBtn.classList.remove('is-disabled');
+    } else {
+        indicator.classList.remove('is-matched');
+        icon.className = 'bi bi-circle';
+        text.textContent = `Paid $${formatCents(totalPaidCents)} · split $${formatCents(totalSplitCents)}`;
+        saveBtn.classList.add('is-disabled');
+    }
+}
+
+async function saveExpense() {
+    const form = document.getElementById('expenseForm');
+    const saveBtn = document.getElementById('saveExpenseBtn');
+    const descriptionInput = document.getElementById('expenseDescription');
+    const description = descriptionInput.value;
+
+    form.querySelectorAll('.is-invalid').forEach(clearEntryValidation);
+
     if (!description.trim()) {
         showErrorToast('Please enter a description for the expense.');
+        descriptionInput.focus();
         return;
     }
 
-    // Calculate total amounts and validate payers
+    // Rows with an empty amount are treated as untouched and skipped;
+    // rows with a non-empty but invalid amount block the save.
     let totalPaidCents = 0;
     let firstInvalidInput = null;
     const payers = [];
-    for (const payerEntry of expenseEntry.querySelectorAll('.payer-entry')) {
-        const amountInput = payerEntry.querySelector('.amount-input');
+    for (const row of document.querySelectorAll('#payersList .entry-row')) {
+        const amountInput = row.querySelector('.amount-input');
+        if (amountInput.value.trim() === '') continue;
         const amount = parseAmountInput(amountInput);
         if (amount === null || amount <= 0) {
-            const invalidInput = markEntryInvalid(payerEntry);
+            const invalidInput = markEntryInvalid(row);
             firstInvalidInput = firstInvalidInput || invalidInput;
             continue;
         }
-
-        totalPaidCents += await getConvertedCents(payerEntry, displayCurrency);
+        totalPaidCents += await getConvertedCents(row, DISPLAY_CURRENCY);
         payers.push({
-            person: payerEntry.querySelector('.payer-select').value,
+            person: row.querySelector('.person-select').value,
             amount: amount,
-            currency: payerEntry.querySelector('.currency-select').value
+            currency: row.querySelector('.currency-select').value
         });
     }
-
-    // If any payer has invalid amount, stop the save process
     if (firstInvalidInput) {
         focusInvalidInput(firstInvalidInput);
         showErrorToast('Please enter valid positive amounts for all payers.');
         return;
     }
 
-    // Check splits and validate amounts
     let totalSplitCents = 0;
     const splits = [];
-    for (const splitEntry of expenseEntry.querySelectorAll('.split-entry')) {
-        const amountInput = splitEntry.querySelector('.amount-input');
+    for (const row of document.querySelectorAll('#splitsList .entry-row')) {
+        const amountInput = row.querySelector('.amount-input');
+        if (amountInput.value.trim() === '') continue;
         const amount = parseAmountInput(amountInput);
         if (amount === null || amount <= 0) {
-            const invalidInput = markEntryInvalid(splitEntry);
+            const invalidInput = markEntryInvalid(row);
             firstInvalidInput = firstInvalidInput || invalidInput;
             continue;
         }
-
-        totalSplitCents += await getConvertedCents(splitEntry, displayCurrency);
+        totalSplitCents += await getConvertedCents(row, DISPLAY_CURRENCY);
         splits.push({
-            person: splitEntry.querySelector('.split-select').value,
+            person: row.querySelector('.person-select').value,
             amount: amount,
-            currency: splitEntry.querySelector('.currency-select').value
+            currency: row.querySelector('.currency-select').value
         });
     }
-
-    // If any split has invalid amount, stop the save process
     if (firstInvalidInput) {
         focusInvalidInput(firstInvalidInput);
         showErrorToast('Please enter valid positive amounts for all splits.');
         return;
     }
 
-    // Check if amounts match
+    if (payers.length === 0 || splits.length === 0) {
+        showErrorToast('Enter amounts for who paid and how it splits.');
+        return;
+    }
+
     if (!amountsMatchInCents(totalPaidCents, totalSplitCents)) {
-        showErrorToast('The total amount paid must equal the total amount split.');
+        showErrorToast('The total paid must equal the total split.');
         return;
     }
 
     const expense = {
         description,
-        displayCurrency,
+        displayCurrency: DISPLAY_CURRENCY,
         payers,
         splits
     };
 
-    const expenseId = expenseEntry.dataset.expenseId || null;
-    btn.disabled = true;
+    const expenseId = editingExpenseId;
+    saveBtn.disabled = true;
     try {
         const savedExpense = await saveExpenseToBackend(expense, expenseId);
         if (expenseId) {
@@ -707,53 +736,40 @@ async function saveExpense(btn) {
             savedExpenses.push(savedExpense);
         }
 
+        invalidateSettlement();
         await updateExpenseTable();
-        expenseEntry.remove();
-        showSuccessToast(expenseId ? 'Expense updated successfully!' : 'Expense saved successfully!');
+        resetExpenseForm();
+        switchTab('view');
     } catch (error) {
         console.error('Error saving expense:', error);
         showErrorToast('Error saving expense. Please try again.');
-        btn.disabled = false;
+    } finally {
+        saveBtn.disabled = false;
     }
 }
 
+function editExpense(id) {
+    const expense = savedExpenses.find(e => e.id === id);
+    if (!expense) return;
 
-// Helper function to show error toast
-function showErrorToast(message) {
-    const toastDiv = document.createElement('div');
-    toastDiv.innerHTML = `
-        <div class="toast-container position-fixed bottom-0 end-0 p-3">
-            <div class="toast bg-danger text-white" role="alert" aria-live="assertive" aria-atomic="true">
-                <div class="toast-header bg-danger text-white">
-                    <strong class="me-auto">Error</strong>
-                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
-                </div>
-                <div class="toast-body">
-                    ${message}
-                </div>
-            </div>
-        </div>`;
-    document.body.appendChild(toastDiv);
-    const toast = new bootstrap.Toast(toastDiv.querySelector('.toast'));
-    toast.show();
-}
+    editingExpenseId = id;
+    document.getElementById('expenseDescription').value = expense.description;
 
-// Helper function to show success toast
-function showSuccessToast(message) {
-    const toastDiv = document.createElement('div');
-    toastDiv.innerHTML = `
-        <div class="toast-container position-fixed bottom-0 end-0 p-3">
-            <div class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-                <div class="toast-header">
-                    <strong class="me-auto">Success</strong>
-                    <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-                </div>
-                <div class="toast-body">${message}</div>
-            </div>
-        </div>`;
-    document.body.appendChild(toastDiv);
-    const toast = new bootstrap.Toast(toastDiv.querySelector('.toast'));
-    toast.show();
+    const payersList = document.getElementById('payersList');
+    const splitsList = document.getElementById('splitsList');
+    payersList.innerHTML = '';
+    splitsList.innerHTML = '';
+    expense.payers.forEach(p => {
+        payersList.appendChild(createEntryRow({ person: p.person, amount: p.amount, currency: p.currency }));
+    });
+    expense.splits.forEach(s => {
+        splitsList.appendChild(createEntryRow({ person: s.person, amount: s.amount, currency: s.currency }));
+    });
+    refreshFormSelects();
+
+    setEditingUI(true);
+    switchTab('add');
+    recomputeTotalsIndicator();
 }
 
 async function deleteExpense(id) {
@@ -761,6 +777,7 @@ async function deleteExpense(id) {
         try {
             await deleteExpenseFromBackend(id);
             savedExpenses = savedExpenses.filter(e => e.id !== id);
+            invalidateSettlement();
             await updateExpenseTable();
         } catch (error) {
             console.error('Error deleting expense:', error);
@@ -769,485 +786,435 @@ async function deleteExpense(id) {
     }
 }
 
-async function updateExpenseTable() {
-    const tbody = document.getElementById('expenseTableBody');
-    const mobileCardView = document.getElementById('expenseMobileCards');
-    const isMobile = window.innerWidth < 768; // Bootstrap's md breakpoint
-    
-    // Process all expenses to gather the formatted data
-    const processedExpenses = await Promise.all(savedExpenses.map(async expense => {
-        const displayCurrency = expense.displayCurrency;
-
-        const payersWithConvertedAmounts = await Promise.all(expense.payers.map(async p => {
-            const rate = await getExchangeRate(p.currency, displayCurrency);
-            const convertedAmount = p.amount * rate;
-            // Format amount with commas and always 2 decimal places
-            const formattedAmount = p.amount.toLocaleString('en-US', {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-            });
-            return {
-                ...p,
-                convertedAmount,
-                originalAmount: `${p.currency} ${formattedAmount}`
-            };
-        }));
-
-        const splitsWithConvertedAmounts = await Promise.all(expense.splits.map(async s => {
-            const rate = await getExchangeRate(s.currency, displayCurrency);
-            const convertedAmount = s.amount * rate;
-            // Format amount with commas and always 2 decimal places
-            const formattedAmount = s.amount.toLocaleString('en-US', {
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2
-            });
-            return {
-                ...s,
-                convertedAmount,
-                originalAmount: `${s.currency} ${formattedAmount}`
-            };
-        }));
-
-        // Format "Who Paid" as a organized list with line breaks between participants, identical to "Split Between"
-        const payersText = payersWithConvertedAmounts.map(p =>
-            `<div class="split-item mb-1">${p.person} <span class="text-muted">(${p.originalAmount})</span></div>`
-        ).join('');
-
-        // Format "Split Between" as a organized list with line breaks between participants
-        const splitsText = splitsWithConvertedAmounts.map(s =>
-            `<div class="split-item mb-1">${s.person} <span class="text-muted">(${s.originalAmount})</span></div>`
-        ).join('');
-
-        const totalPaidConverted = payersWithConvertedAmounts.reduce((sum, p) => sum + p.convertedAmount, 0);
-        
-        // Format amount with commas and always 2 decimal places
-        const formattedAmount = totalPaidConverted.toLocaleString('en-US', {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-        });
-        
-        return {
-            id: expense.id,
-            description: expense.description,
-            payersText: payersText,
-            splitsText: splitsText,
-            displayCurrency: displayCurrency,
-            formattedAmount: formattedAmount
-        };
-    }));
-    
-    // Update the desktop table view
-    const tableRows = processedExpenses.map(expense => `
-        <tr>
-            <td>${expense.description}</td>
-            <td>${expense.payersText}</td>
-            <td>${expense.displayCurrency} ${expense.formattedAmount}</td>
-            <td>${expense.displayCurrency}</td>
-            <td>${expense.splitsText}</td>
-            <td>
-                <div class="btn-group">
-                    <button class="btn btn-sm btn-primary" onclick="editExpense(${expense.id})">
-                        <i class="bi bi-pencil"></i>
-                    </button>
-                    <button class="btn btn-sm btn-danger" onclick="deleteExpense(${expense.id})">
-                        <i class="bi bi-trash"></i>
-                    </button>
-                </div>
-            </td>
-        </tr>
-    `);
-    
-    tbody.innerHTML = tableRows.join('');
-    
-    // Update the mobile card view
-    const mobileCards = processedExpenses.map(expense => `
-        <div class="card mb-3 expense-card">
-            <div class="card-header d-flex justify-content-between align-items-center">
-                <h5 class="mb-0">${expense.description}</h5>
-                <div class="badge bg-primary">${expense.displayCurrency} ${expense.formattedAmount}</div>
-            </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <div class="text-muted mb-1"><small>Who Paid</small></div>
-                    <div>${expense.payersText}</div>
-                </div>
-                <div class="mb-3">
-                    <div class="text-muted mb-1"><small>Split Between</small></div>
-                    <div>${expense.splitsText}</div>
-                </div>
-            </div>
-            <div class="card-footer bg-light">
-                <div class="d-flex justify-content-end">
-                    <div class="btn-group">
-                        <button class="btn btn-sm btn-primary" onclick="editExpense(${expense.id})">
-                            <i class="bi bi-pencil"></i> Edit
-                        </button>
-                        <button class="btn btn-sm btn-danger" onclick="deleteExpense(${expense.id})">
-                            <i class="bi bi-trash"></i> Delete
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    `);
-    
-    mobileCardView.innerHTML = mobileCards.join('');
-    
-    // Toggle visibility based on screen size
-    const tableContainer = document.getElementById('expenseTableContainer');
-    const cardContainer = document.getElementById('expenseMobileContainer');
-    
-    if (isMobile) {
-        tableContainer.classList.add('d-none');
-        cardContainer.classList.remove('d-none');
-    } else {
-        tableContainer.classList.remove('d-none');
-        cardContainer.classList.add('d-none');
+async function splitEvenly() {
+    let totalPaidCents = 0;
+    for (const row of document.querySelectorAll('#payersList .entry-row')) {
+        totalPaidCents += await getConvertedCents(row, DISPLAY_CURRENCY);
     }
-}
 
-function editExpense(id) {
-    const expense = savedExpenses.find(e => e.id === id);
-    if (!expense) return;
-
-    if (!confirm('Do you want to edit this expense?')) {
+    const splitRows = document.querySelectorAll('#splitsList .entry-row');
+    if (splitRows.length === 0) {
+        showErrorToast('Add people to split between first.');
         return;
     }
 
-    // Switch to add expenses tab
-    document.getElementById('add-expenses-tab').click();
+    const baseSplitCents = Math.floor(totalPaidCents / splitRows.length);
+    const remainderCents = totalPaidCents % splitRows.length;
 
-    // Add a new expense form
-    addExpenseRow();
-    const expenseEntry = document.querySelector('.expense-entry:last-child');
-    expenseEntry.dataset.expenseId = expense.id;
-
-    // Fill in the description
-    expenseEntry.querySelector('.expense-description').value = expense.description;
-    expenseEntry.querySelector('.display-currency-select').value = expense.displayCurrency;
-
-    // Add payers
-    const payersList = expenseEntry.querySelector('.payers-list');
-    payersList.innerHTML = '';
-    expense.payers.forEach(payer => {
-        const template = document.getElementById('payerTemplate');
-        const clone = template.content.cloneNode(true);
-
-        clone.querySelector('.payer-select').innerHTML = participants
-            .map(p => `<option value="${p}"${p === payer.person ? ' selected' : ''}>${p}</option>`)
-            .join('');
-
-        clone.querySelector('.amount-input').value = payer.amount;
-        clone.querySelector('.currency-select').value = payer.currency;
-
-        payersList.appendChild(clone);
+    splitRows.forEach((row, index) => {
+        const splitCents = baseSplitCents + (index < remainderCents ? 1 : 0);
+        row.querySelector('.amount-input').value = (splitCents / 100).toFixed(2);
+        row.querySelector('.currency-select').value = DISPLAY_CURRENCY;
+        clearEntryValidation(row);
     });
 
-    // Add splits
-    const splitsList = expenseEntry.querySelector('.splits-list');
-    splitsList.innerHTML = '';
-    expense.splits.forEach(split => {
-        const template = document.getElementById('splitTemplate');
-        const clone = template.content.cloneNode(true);
-
-        clone.querySelector('.split-select').innerHTML = participants
-            .map(p => `<option value="${p}"${p === split.person ? ' selected' : ''}>${p}</option>`)
-            .join('');
-
-        clone.querySelector('.amount-input').value = split.amount;
-        clone.querySelector('.currency-select').value = split.currency;
-
-        splitsList.appendChild(clone);
-    });
-
-    const saveBtn = expenseEntry.querySelector('.btn-success');
-    saveBtn.innerHTML = '<i class="bi bi-check-lg me-1"></i>Update';
-
-    // Update totals
-    updateTotals(expenseEntry.querySelector('.display-currency-select'));
+    recomputeTotalsIndicator();
 }
 
+// ===== Expenses list =====
+async function updateExpenseTable() {
+    const processed = await Promise.all(savedExpenses.map(async expense => {
+        const payers = await Promise.all(expense.payers.map(async p => {
+            const rate = await getExchangeRate(p.currency, DISPLAY_CURRENCY);
+            return {
+                person: p.person,
+                converted: p.amount * rate,
+                original: `${p.currency} ${formatNumber(p.amount)}`
+            };
+        }));
+        const splits = expense.splits.map(s => ({
+            person: s.person,
+            original: `${s.currency} ${formatNumber(s.amount)}`
+        }));
+        const total = payers.reduce((sum, p) => sum + p.converted, 0);
+        return { id: expense.id, description: expense.description, payers, splits, total };
+    }));
 
+    const grandTotal = processed.reduce((sum, e) => sum + e.total, 0);
 
-// Global variable to store settlement data for PDF export - prevents issues with formatted numbers
-window.settlementData = {
-    settlements: {},
-    transfers: [],
-    baseCurrency: "USD"
-};
+    document.getElementById('expenseTableBody').innerHTML = processed.map(e => `
+        <tr>
+            <td class="cell-title">${escapeHtml(e.description)}</td>
+            <td>${e.payers.map(p => `<div class="person-line">${escapeHtml(p.person)} <span class="orig">${p.original}</span></div>`).join('')}</td>
+            <td>${e.splits.map(s => `<div class="person-line">${escapeHtml(s.person)} <span class="orig">${s.original}</span></div>`).join('')}</td>
+            <td class="cell-amount">$${formatNumber(e.total)}</td>
+            <td class="cell-actions">
+                <button type="button" class="row-action row-action--edit" data-action="edit-expense" data-id="${e.id}" aria-label="Edit expense"><i class="bi bi-pencil"></i></button>
+                <button type="button" class="row-action row-action--delete" data-action="delete-expense" data-id="${e.id}" aria-label="Delete expense"><i class="bi bi-trash"></i></button>
+            </td>
+        </tr>
+    `).join('');
 
-// Helper function to safely add commas to numbers for PDF display
-function addCommasToNumber(numStr) {
-    // Add commas to the whole number portion, preserve decimal part
-    const parts = numStr.toString().split('.');
-    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    return parts.join('.');
+    document.getElementById('expenseCards').innerHTML = processed.map(e => `
+        <div class="expense-card-m">
+            <div class="ecm-head">
+                <span class="ecm-title">${escapeHtml(e.description)}</span>
+                <span class="ecm-total">$${formatNumber(e.total)}</span>
+            </div>
+            <div class="ecm-grid">
+                <div class="ecm-col">
+                    <div class="ecm-label">Paid by</div>
+                    ${e.payers.map(p => `<div class="ecm-line"><span class="name">${escapeHtml(p.person)}</span><span class="orig">${p.original}</span></div>`).join('')}
+                </div>
+                <div class="ecm-col">
+                    <div class="ecm-label">Split between</div>
+                    ${e.splits.map(s => `<div class="ecm-line"><span class="name">${escapeHtml(s.person)}</span><span class="orig">${s.original}</span></div>`).join('')}
+                </div>
+            </div>
+            <div class="ecm-actions">
+                <button type="button" class="ecm-edit" data-action="edit-expense" data-id="${e.id}"><i class="bi bi-pencil"></i>Edit</button>
+                <button type="button" class="ecm-delete" data-action="delete-expense" data-id="${e.id}"><i class="bi bi-trash"></i>Delete</button>
+            </div>
+        </div>
+    `).join('');
+
+    const countText = `${processed.length} expense${processed.length === 1 ? '' : 's'}`;
+    document.getElementById('expenseCountFooter').textContent = countText;
+    document.getElementById('expenseCountFooterMobile').textContent = countText;
+    document.getElementById('grandTotal').textContent = `$${formatNumber(grandTotal)}`;
+    document.getElementById('grandTotalMobile').textContent = `$${formatNumber(grandTotal)}`;
+
+    renderTabState();
+    updateEmptyStates();
+}
+
+// ===== Settle up =====
+function invalidateSettlement() {
+    settled = false;
+    paidTransfers.clear();
+    if (countUpRaf) {
+        cancelAnimationFrame(countUpRaf);
+        countUpRaf = null;
+    }
+    window.settlementData = {
+        settlements: {},
+        transfers: [],
+        balances: [],
+        baseCurrency: DISPLAY_CURRENCY,
+        exchangeRateInfo: null
+    };
+    document.getElementById('balancesGrid').innerHTML = '';
+    document.getElementById('transfersList').innerHTML = '';
+    document.getElementById('allPaidBanner').hidden = true;
+    document.getElementById('exchangeRateInfo').textContent = '';
+    updateEmptyStates();
+}
+
+// Greedy multi-creditor matching: largest debtor pays largest creditor first.
+function computeTransfers(settlements) {
+    const creditors = Object.entries(settlements)
+        .filter(([, amount]) => amount > 0.005)
+        .sort((a, b) => b[1] - a[1])
+        .map(([person, amount]) => ({ person, amt: amount }));
+    const debtors = Object.entries(settlements)
+        .filter(([, amount]) => amount < -0.005)
+        .sort((a, b) => a[1] - b[1])
+        .map(([person, amount]) => ({ person, amt: -amount }));
+
+    const transfers = [];
+    let ci = 0;
+    debtors.forEach(d => {
+        let remaining = d.amt;
+        while (remaining > 0.005 && ci < creditors.length) {
+            const c = creditors[ci];
+            const pay = Math.min(remaining, c.amt);
+            transfers.push({ from: d.person, to: c.person, amount: pay });
+            remaining -= pay;
+            c.amt -= pay;
+            if (c.amt < 0.005) ci++;
+        }
+    });
+    return transfers;
+}
+
+async function computeBalances(settlements, baseCurrency) {
+    return Promise.all(participants.map(async person => {
+        let paid = 0;
+        for (const expense of savedExpenses) {
+            for (const p of expense.payers) {
+                if (p.person !== person) continue;
+                const rate = await getExchangeRate(p.currency, baseCurrency);
+                paid += p.amount * rate;
+            }
+        }
+        const net = settlements[person] || 0;
+        return { person, paid, share: paid - net, net };
+    }));
 }
 
 async function calculateSettlement() {
     const baseCurrency = document.getElementById('baseCurrency').value;
 
-    fetch('/calculate', {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-            participants,
-            expenses: savedExpenses,
-            baseCurrency
-        })
-    })
-    .then(response => response.json())
-    .then(data => {
-        // Store the raw settlement data for PDF export
-        window.settlementData = {
-            settlements: {...data.settlements}, // Copy the raw settlement values
-            transfers: [], // Will be populated below
-            baseCurrency: baseCurrency
-        };
-        const resultsDiv = document.getElementById('settlementResults');
-        resultsDiv.innerHTML = '';
-
-        // Build the summary card
-        let summaryCardHTML = `
-            <div class="card mb-4">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0 d-flex align-items-center">
-                        <i class="bi bi-table me-2"></i>
-                        <span>Summary</span>
-                    </h5>
-                </div>
-                <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table table-sm">
-                            <thead>
-                                <tr>
-                                    <th>Participant</th>
-                                    <th>Total Paid</th>
-                                    <th>Should Pay</th>
-                                    <th>Net Balance</th>
-                                </tr>
-                            </thead>
-                            <tbody>`;
-                            
-        Object.entries(data.settlements).forEach(([person, amount]) => {
-            const totalPaid = savedExpenses.reduce((sum, exp) => {
-                const personPaid = exp.payers
-                    .filter(p => p.person === person)
-                    .reduce((psum, p) => psum + (p.amount || 0), 0);
-                return sum + personPaid;
-            }, 0);
-
-            const shouldPay = totalPaid - amount;
-
-            summaryCardHTML += `
-                <tr>
-                    <td>${person}</td>
-                    <td>${baseCurrency} ${totalPaid.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</td>
-                    <td>${baseCurrency} ${shouldPay.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</td>
-                    <td class="${amount >= 0 ? 'text-success' : 'text-danger'}">
-                        ${baseCurrency} ${amount >= 0 ? '+' : '-'}${Math.abs(amount).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}
-                    </td>
-                </tr>`;
+    try {
+        const response = await fetch('/calculate', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                participants,
+                expenses: savedExpenses,
+                baseCurrency
+            })
         });
-                            
-        summaryCardHTML += `
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>`;
-            
-        // Add summary card to results div
-        resultsDiv.innerHTML += summaryCardHTML;
-
-        // Build the settlement results card
-        let settlementCardHTML = `
-            <div class="card mt-4">
-                <div class="card-header bg-light">
-                    <h5 class="mb-0 d-flex align-items-center">
-                        <i class="bi bi-cash-stack me-2"></i>
-                        <span>Settlement Results</span>
-                    </h5>
-                </div>
-                <div class="card-body">`;
-                
-        // Add each person's settlement result
-        Object.entries(data.settlements).forEach(([person, amount]) => {
-            const amountClass = amount >= 0 ? 'positive-amount' : 'negative-amount';
-            settlementCardHTML += `
-                <div class="mb-2">
-                    <strong>${person}:</strong>
-                    <span class="${amountClass}">
-                        ${amount >= 0 ? 'Gets back' : 'Owes'}
-                        ${baseCurrency} ${amount >= 0 ? '+' : '-'}${Math.abs(amount).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}
-                    </span>
-                </div>`;
-        });
-
-        // Close the settlement results card
-        settlementCardHTML += `
-                </div>
-            </div>`;
-            
-        // Add settlement card to results div
-        resultsDiv.innerHTML += settlementCardHTML;
-
-        const settlements = data.settlements;
-        const debtors = Object.entries(settlements)
-            .filter(([_, amount]) => amount < 0)
-            .sort((a, b) => a[1] - b[1]);
-        const creditors = Object.entries(settlements)
-            .filter(([_, amount]) => amount > 0)
-            .sort((a, b) => b[1] - a[1]);
-
-        if (creditors.length > 0 && debtors.length > 0) {
-            // Build the recommended transfers card
-            let transfersCardHTML = `
-                <div class="card mt-4">
-                    <div class="card-header bg-light">
-                        <h5 class="mb-0 d-flex align-items-center">
-                            <i class="bi bi-lightbulb me-2"></i>
-                            <span>Recommended Transfers</span>
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <p class="text-muted small mb-3">Here's the most efficient way to settle all debts:</p>`;
-
-            const mainCreditor = creditors[0];
-            // Store transfers for PDF export
-            window.settlementData.transfers = [];
-            
-            debtors.forEach(([debtor, amount]) => {
-                // Store raw transfer data for PDF export (no formatting)
-                window.settlementData.transfers.push({
-                    from: debtor,
-                    to: mainCreditor[0],
-                    amount: Math.abs(amount),
-                    currency: baseCurrency
-                });
-                
-                transfersCardHTML += `
-                    <div class="mb-2">
-                        <strong>${debtor}</strong> pays 
-                        <strong>${mainCreditor[0]}</strong>: 
-                        ${baseCurrency} ${Math.abs(amount).toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}
-                    </div>`;
-            });
-
-            for (let i = 1; i < creditors.length; i++) {
-                const [creditor, amount] = creditors[i];
-                
-                // Store raw transfer data for PDF export (no formatting)
-                window.settlementData.transfers.push({
-                    from: mainCreditor[0],
-                    to: creditor,
-                    amount: amount, 
-                    currency: baseCurrency
-                });
-                
-                transfersCardHTML += `
-                    <div class="mb-2">
-                        <strong>${mainCreditor[0]}</strong> pays 
-                        <strong>${creditor}</strong>: 
-                        ${baseCurrency} ${amount.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})}
-                    </div>`;
-            }
-
-            transfersCardHTML += `
-                    </div>
-                </div>`;
-                
-            // Add transfers card to results div
-            resultsDiv.innerHTML += transfersCardHTML;
+        if (!response.ok) {
+            throw new Error('Failed to calculate settlement');
         }
+        const data = await response.json();
 
-        const exchangeRateInfo = document.getElementById('exchangeRateInfo');
-        const timestamp = new Date(data.exchangeRateInfo.timestamp * 1000).toLocaleString();
-        exchangeRateInfo.innerHTML = `
-            <i class="bi bi-info-circle me-1"></i>
-            Exchange rates provided by ${data.exchangeRateInfo.source}, 
-            last updated: ${timestamp}
-        `;
-    });
+        const transfers = computeTransfers(data.settlements);
+        const balances = await computeBalances(data.settlements, baseCurrency);
+
+        settled = true;
+        paidTransfers.clear();
+        window.settlementData = {
+            settlements: { ...data.settlements },
+            transfers: transfers.map(t => ({ ...t, currency: baseCurrency })),
+            balances,
+            baseCurrency,
+            exchangeRateInfo: data.exchangeRateInfo
+        };
+        renderSettlement();
+    } catch (error) {
+        console.error('Error calculating settlement:', error);
+        showErrorToast('Error calculating settlement. Please try again.');
+    }
 }
 
-const currencyOptions = `
-    <option value="USD">USD - US Dollar</option>
-    <option value="EUR">EUR - Euro</option>
-    <option value="JPY">JPY - Japanese Yen</option>
-    <option value="GBP">GBP - British Pound</option>
-    <option value="CNY">CNY - Chinese Yuan</option>
-    <option value="AUD">AUD - Australian Dollar</option>
-    <option value="CAD">CAD - Canadian Dollar</option>
-    <option value="CHF">CHF - Swiss Franc</option>
-    <option value="HKD">HKD - Hong Kong Dollar</option>
-    <option value="SGD">SGD - Singapore Dollar</option>
-    <option value="SEK">SEK - Swedish Krona</option>
-    <option value="KRW">KRW - South Korean Won</option>
-    <option value="INR">INR - Indian Rupee</option>
-    <option value="BRL">BRL - Brazilian Real</option>
-    <option value="RUB">RUB - Russian Ruble</option>
-    <option value="ZAR">ZAR - South African Rand</option>
-    <option value="MXN">MXN - Mexican Peso</option>
-    <option value="IDR">IDR - Indonesian Rupiah</option>
-    <option value="TRY">TRY - Turkish Lira</option>
-    <option value="SAR">SAR - Saudi Riyal</option>
-    `;
+function renderSettlement() {
+    const { balances, transfers, baseCurrency, exchangeRateInfo } = window.settlementData;
 
-document.querySelectorAll('template').forEach(template => {
-    const currencySelects = template.content.querySelectorAll('.currency-select');
-    currencySelects.forEach(select => {
-        select.innerHTML = currencyOptions;
-    });
-});
+    document.getElementById('balancesGrid').innerHTML = balances.map((b, i) => `
+        <div class="balance-card" style="animation-delay: ${i * 70}ms">
+            <div class="balance-name">${escapeHtml(b.person)}</div>
+            <div class="balance-net ${b.net >= 0 ? 'amount--pos' : 'amount--neg'}" data-target="${b.net}">${b.net >= 0 ? '+' : '−'}${formatMoney(0, baseCurrency)}</div>
+            <div class="balance-detail">paid ${formatMoney(b.paid, baseCurrency)} · share ${formatMoney(b.share, baseCurrency)}</div>
+        </div>
+    `).join('');
 
-document.addEventListener('change', async event => {
-    if (event.target.classList.contains('display-currency-select') ||
-        event.target.classList.contains('amount-input') ||
-        event.target.classList.contains('currency-select')) {
-        await updateTotals(event.target);
-    }
-});
+    document.getElementById('transfersList').innerHTML = transfers.length === 0
+        ? '<div class="tap-hint">No transfers needed — everyone is already square.</div>'
+        : transfers.map((t, i) => `
+            <div class="transfer-row" data-action="toggle-transfer" data-index="${i}" role="button" tabindex="0" aria-label="Mark transfer from ${escapeHtml(t.from)} to ${escapeHtml(t.to)} as paid">
+                <i class="bi bi-circle t-icon"></i>
+                <span class="t-name">${escapeHtml(t.from)}</span>
+                <i class="bi bi-arrow-right t-arrow"></i>
+                <span class="t-name">${escapeHtml(t.to)}</span>
+                <span class="leader"></span>
+                <span class="t-amount">${formatMoney(t.amount, baseCurrency)}</span>
+            </div>
+        `).join('');
 
-document.addEventListener('input', event => {
-    if (event.target.classList.contains('amount-input')) {
-        clearEntryValidation(event.target.closest('.payer-entry, .split-entry'));
-    }
-});
+    document.getElementById('allPaidBanner').hidden = true;
 
-async function splitEvenly(btn) {
-    const expenseEntry = btn.closest('.expense-entry');
-    const displayCurrency = expenseEntry.querySelector('.display-currency-select').value;
-
-    // Calculate total paid amount in display currency
-    let totalPaidCents = 0;
-    for (const payerEntry of expenseEntry.querySelectorAll('.payer-entry')) {
-        totalPaidCents += await getConvertedCents(payerEntry, displayCurrency);
+    if (exchangeRateInfo) {
+        const timestamp = new Date(exchangeRateInfo.timestamp * 1000).toLocaleString();
+        document.getElementById('exchangeRateInfo').innerHTML =
+            `<i class="bi bi-info-circle"></i>Rates from ${escapeHtml(exchangeRateInfo.source)}, updated hourly · last ${escapeHtml(timestamp)}`;
     }
 
-    // Get all split entries
-    const splitEntries = expenseEntry.querySelectorAll('.split-entry');
-    if (splitEntries.length === 0) {
-        alert('Please add participants to split between first');
+    updateEmptyStates();
+    animateCountUp();
+}
+
+// Count the net balances up from 0 over 900ms with a cubic ease-out.
+function animateCountUp() {
+    const nets = Array.from(document.querySelectorAll('.balance-net'));
+    const { baseCurrency } = window.settlementData;
+    if (countUpRaf) cancelAnimationFrame(countUpRaf);
+
+    const start = performance.now();
+    const duration = 900;
+    const step = now => {
+        const t = Math.min(1, (now - start) / duration);
+        const eased = 1 - Math.pow(1 - t, 3);
+        nets.forEach(el => {
+            const target = parseFloat(el.dataset.target) || 0;
+            el.textContent = `${target >= 0 ? '+' : '−'}${formatMoney(Math.abs(target) * eased, baseCurrency)}`;
+        });
+        countUpRaf = t < 1 ? requestAnimationFrame(step) : null;
+    };
+    countUpRaf = requestAnimationFrame(step);
+}
+
+function toggleTransferPaid(index) {
+    const row = document.querySelector(`.transfer-row[data-index="${index}"]`);
+    if (!row) return;
+
+    if (paidTransfers.has(index)) {
+        paidTransfers.delete(index);
+    } else {
+        paidTransfers.add(index);
+    }
+    const isPaid = paidTransfers.has(index);
+    row.classList.toggle('is-paid', isPaid);
+    row.querySelector('.t-icon').className = isPaid ? 'bi bi-check-circle-fill t-icon' : 'bi bi-circle t-icon';
+
+    const total = window.settlementData.transfers.length;
+    document.getElementById('allPaidBanner').hidden = !(total > 0 && paidTransfers.size === total);
+}
+
+function populateBaseCurrencySelect() {
+    document.getElementById('baseCurrency').innerHTML = CURRENCIES
+        .map(c => `<option value="${c.code}">${c.code} — ${c.name}</option>`)
+        .join('');
+}
+
+// ===== PDF export =====
+function addCommasToNumber(numStr) {
+    const parts = numStr.toString().split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return parts.join('.');
+}
+
+async function exportToPDF() {
+    if (!settled || window.settlementData.balances.length === 0) {
+        showErrorToast('Calculate the settlement first.');
         return;
     }
 
-    const baseSplitCents = Math.floor(totalPaidCents / splitEntries.length);
-    const remainderCents = totalPaidCents % splitEntries.length;
+    const { balances, baseCurrency } = window.settlementData;
+    const expenseTotals = await Promise.all(savedExpenses.map(async expense => {
+        let total = 0;
+        for (const p of expense.payers) {
+            total += p.amount * await getExchangeRate(p.currency, DISPLAY_CURRENCY);
+        }
+        return total;
+    }));
 
-    // Update all split amounts
-    splitEntries.forEach((splitEntry, index) => {
-        const amountInput = splitEntry.querySelector('.amount-input');
-        const currencySelect = splitEntry.querySelector('.currency-select');
-        const splitCents = baseSplitCents + (index < remainderCents ? 1 : 0);
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    let yPos = 20;
 
-        amountInput.value = (splitCents / 100).toFixed(2);
-        currencySelect.value = displayCurrency;
-        clearEntryValidation(splitEntry);
+    // Title and basic info
+    doc.setFontSize(24);
+    doc.setTextColor(26, 26, 23);
+    doc.text('BrokeWise', 20, yPos);
+    yPos += 10;
+
+    doc.setFontSize(16);
+    doc.text('Expense Report', 20, yPos);
+    yPos += 10;
+
+    doc.setFontSize(10);
+    doc.setTextColor(100, 100, 100);
+    doc.text(`Generated on: ${new Date().toLocaleDateString()}`, 20, yPos);
+    yPos += 15;
+
+    // Participants section
+    doc.setFontSize(14);
+    doc.setTextColor(26, 26, 23);
+    doc.text('Participants', 20, yPos);
+    yPos += 10;
+
+    doc.setFontSize(10);
+    doc.setTextColor(0, 0, 0);
+    participants.forEach(participant => {
+        doc.text(`• ${participant}`, 25, yPos);
+        yPos += 6;
+    });
+    yPos += 10;
+
+    // Expenses section
+    doc.setFontSize(14);
+    doc.setTextColor(26, 26, 23);
+    doc.text('Expenses', 20, yPos);
+    yPos += 10;
+
+    const headers = ['Description', 'Paid By', 'Amount', 'Split Between'];
+    const colWidths = [50, 45, 30, 45];
+    doc.setFontSize(9);
+    doc.setTextColor(0, 0, 0);
+
+    doc.setFillColor(240, 240, 240);
+    doc.rect(20, yPos - 5, 170, 8, 'F');
+    headers.forEach((header, i) => {
+        let xPos = 20;
+        for (let j = 0; j < i; j++) xPos += colWidths[j];
+        doc.text(header, xPos + 2, yPos);
+    });
+    yPos += 8;
+
+    doc.setFontSize(8);
+    savedExpenses.forEach((expense, index) => {
+        if (yPos > 270) {
+            doc.addPage();
+            yPos = 20;
+        }
+
+        const payers = expense.payers.map(p =>
+            `${p.person} (${p.currency} ${addCommasToNumber(p.amount.toFixed(2))})`
+        ).join('\n');
+
+        const splits = expense.splits.map(s =>
+            `${s.person} (${s.currency} ${addCommasToNumber(s.amount.toFixed(2))})`
+        ).join('\n');
+
+        const displayAmount = `${DISPLAY_CURRENCY} ${addCommasToNumber(expenseTotals[index].toFixed(2))}`;
+
+        let xPos = 20;
+        doc.text(expense.description, xPos + 2, yPos, { maxWidth: colWidths[0] - 4 });
+        xPos += colWidths[0];
+
+        doc.text(payers, xPos + 2, yPos, { maxWidth: colWidths[1] - 4 });
+        xPos += colWidths[1];
+
+        doc.text(displayAmount, xPos + 2, yPos);
+        xPos += colWidths[2];
+
+        doc.text(splits, xPos + 2, yPos, { maxWidth: colWidths[3] - 4 });
+
+        const lineHeight = Math.max(
+            doc.splitTextToSize(expense.description, colWidths[0] - 4).length,
+            doc.splitTextToSize(payers, colWidths[1] - 4).length,
+            doc.splitTextToSize(splits, colWidths[3] - 4).length
+        ) * 4;
+
+        yPos += lineHeight + 4;
     });
 
-    // Update totals
-    await updateTotals(btn);
+    // Settlement Summary on a new page
+    doc.addPage();
+    yPos = 20;
+
+    doc.setFontSize(14);
+    doc.setTextColor(26, 26, 23);
+    doc.text('Settlement Summary', 20, yPos);
+    yPos += 6;
+
+    doc.setFontSize(10);
+    doc.setTextColor(100, 100, 100);
+    doc.text(`Settled in ${baseCurrency}`, 20, yPos);
+    yPos += 10;
+
+    const summaryHeaders = ['Person', 'Total Paid', 'Share', 'Net Balance'];
+    const summaryColWidths = [50, 40, 40, 40];
+    doc.setFontSize(10);
+    doc.setFillColor(240, 240, 240);
+    doc.rect(20, yPos - 5, 170, 8, 'F');
+    doc.setTextColor(0, 0, 0);
+    summaryHeaders.forEach((header, i) => {
+        let xPos = 20;
+        for (let j = 0; j < i; j++) xPos += summaryColWidths[j];
+        doc.text(header, xPos + 2, yPos);
+    });
+    yPos += 10;
+
+    doc.setFontSize(9);
+    balances.forEach(b => {
+        const cells = [
+            b.person,
+            `${baseCurrency} ${addCommasToNumber(b.paid.toFixed(2))}`,
+            `${baseCurrency} ${addCommasToNumber(b.share.toFixed(2))}`,
+            `${b.net >= 0 ? '+' : '-'}${baseCurrency} ${addCommasToNumber(Math.abs(b.net).toFixed(2))}`
+        ];
+        let xPos = 20;
+        cells.forEach((cell, i) => {
+            doc.text(cell, xPos + 2, yPos);
+            xPos += summaryColWidths[i];
+        });
+        yPos += 7;
+    });
+
+    doc.save('brokewise-report.pdf');
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -311,7 +311,17 @@ function cancelPersonAdd() {
     renderPeople();
 }
 
+function personHasExpenses(name) {
+    return savedExpenses.some(e =>
+        e.payers.some(p => p.person === name) ||
+        e.splits.some(s => s.person === name));
+}
+
 function removeParticipant(name) {
+    if (personHasExpenses(name)) {
+        showErrorToast(`${name} is part of an expense — delete that expense first.`);
+        return;
+    }
     participants = participants.filter(p => p !== name);
     saveParticipantsToBackend().catch(error => {
         console.error('Error saving participants:', error);
@@ -380,14 +390,17 @@ function showErrorToast(message) {
         container = document.createElement('div');
         container.className = 'toast-container-ledger';
         container.setAttribute('aria-live', 'polite');
-        document.body.appendChild(container);
+        (document.querySelector('main.page-main') || document.body).appendChild(container);
     }
     const toast = document.createElement('div');
     toast.className = 'toast-ledger';
     toast.setAttribute('role', 'alert');
     toast.innerHTML = `<i class="bi bi-exclamation-circle"></i>${escapeHtml(message)}`;
     container.appendChild(toast);
-    setTimeout(() => toast.remove(), 3500);
+    setTimeout(() => {
+        toast.remove();
+        if (container.children.length === 0) container.remove();
+    }, 3500);
 }
 
 // ===== Backend calls =====

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,8 +26,13 @@
             <a class="brand" href="/">
                 <span class="logo-container">
                     <i class="bi bi-wallet2 wallet-icon"></i>
+                    <i class="bi bi-currency-dollar money-icon"></i>
+                    <i class="bi bi-currency-euro money-icon"></i>
                 </span>
-                <span class="wordmark">brokewise</span>
+                <span class="brand-text">
+                    <span class="wordmark">brokewise</span>
+                    <span class="tagline">pay up</span>
+                </span>
             </a>
             <div class="header-actions">
                 <div class="share-pill">
@@ -35,11 +40,15 @@
                     <span class="share-pill__url" id="shareUrlText">{{ request.url }}</span>
                     <button type="button" class="copy-btn" id="copyLinkBtn" data-action="copy-link" aria-label="Copy group link">Copy</button>
                 </div>
+                <a class="icon-btn" id="newGroupBtn" href="/" title="New sheet — start a fresh group" aria-label="New sheet — start a fresh group">
+                    <i class="bi bi-file-earmark-plus"></i>
+                </a>
                 <button type="button" class="icon-btn" id="themeToggle" data-action="toggle-theme" title="Toggle theme" aria-label="Toggle theme">
                     <i class="bi bi-moon" id="themeToggleIcon"></i>
                 </button>
             </div>
         </div>
+        <div class="container-ledger header-note">This link saves your group automatically (deleted after 90 days of inactivity).</div>
     </header>
 
     <main class="container-ledger page-main">

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,46 +1,56 @@
 <!DOCTYPE html>
-<html lang="en" data-bs-theme="light">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>BrokeWise</title>
-    <link href="https://bootswatch.com/5/flatly/bootstrap.min.css" rel="stylesheet">
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('bw-theme');
+                if (t === 'dark' || t === 'light') {
+                    document.documentElement.setAttribute('data-theme', t);
+                }
+            } catch (e) {}
+        })();
+    </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='css/custom.css') }}" rel="stylesheet">
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
-        <div class="container">
-            <a class="navbar-brand" href="/">
-                <div class="d-flex align-items-center">
-                    <div class="logo-container me-2">
-                        <i class="bi bi-wallet2 wallet-icon"></i>
-                        <i class="bi bi-currency-dollar money-icon"></i>
-                        <i class="bi bi-currency-euro money-icon"></i>
-                    </div>
-                    BrokeWise
-                </div>
+    <header class="site-header">
+        <div class="container-ledger header-inner">
+            <a class="brand" href="/">
+                <span class="logo-container">
+                    <i class="bi bi-wallet2 wallet-icon"></i>
+                </span>
+                <span class="wordmark">brokewise</span>
             </a>
+            <div class="header-actions">
+                <div class="share-pill">
+                    <i class="bi bi-link-45deg share-pill__icon"></i>
+                    <span class="share-pill__url" id="shareUrlText">{{ request.url }}</span>
+                    <button type="button" class="copy-btn" id="copyLinkBtn" data-action="copy-link" aria-label="Copy group link">Copy</button>
+                </div>
+                <button type="button" class="icon-btn" id="themeToggle" data-action="toggle-theme" title="Toggle theme" aria-label="Toggle theme">
+                    <i class="bi bi-moon" id="themeToggleIcon"></i>
+                </button>
+            </div>
         </div>
-    </nav>
+    </header>
 
-    <div class="container mt-4">
+    <main class="container-ledger page-main">
         {% block content %}{% endblock %}
-    </div>
+    </main>
 
-    <footer class="mt-5 py-3 text-center">
-        <div class="container">
-            <small class="text-muted">
-                {% block footer_extra %}{% endblock %}
-                © 2025 BrokeWise. Created by <a href="mailto:tonyhaowu@gmail.com">Tony Wu</a>.<br>
-                Exchange rates provided by ExchangeRate API, updated hourly.
-            </small>
-        </div>
+    <footer class="site-footer">
+        <small>© 2026 BrokeWise · Created by <a href="mailto:tonyhaowu@gmail.com">Tony Wu</a> · Exchange rates by ExchangeRate API</small>
     </footer>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='js/app.js') }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -64,7 +64,7 @@
             </div>
         </div>
     </div>
-    <div class="helper-text" id="addHelperText"><i class="bi bi-info-circle"></i>Amounts can be in any currency — they're converted automatically. Inactive groups may be removed after 90 days.</div>
+    <div class="helper-text" id="addHelperText"><i class="bi bi-info-circle"></i>Amounts can be in any currency — they're converted automatically.</div>
 </div>
 
 <!-- Expenses -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,277 +1,173 @@
 {% extends "base.html" %}
 
 {% block content %}
-<!-- Add a Share URL section at the top -->
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="alert alert-info d-flex align-items-center">
-            <i class="bi bi-link-45deg me-2 fs-4"></i>
-            <div class="flex-grow-1">
-                Share this URL with your group to collaborate on expenses:
-                <div class="input-group mt-2">
-                    <input type="text" class="form-control" value="{{ request.url }}" readonly id="shareUrl" onclick="this.select();">
-                </div>
-            </div>
-        </div>
-        <p class="text-muted small mt-1"><i class="bi bi-info-circle me-1"></i>Inactive expense groups may be removed after 90 days.</p>
+<!-- People -->
+<div class="section">
+    <div class="micro-label">People</div>
+    <div class="people-row" id="peopleRow">
+        <!-- Chips rendered by JS; the add affordance below is moved to the end on each render -->
+        <input type="text" class="chip-input" id="personInput" placeholder="Name" autocomplete="off" hidden>
+        <button type="button" class="chip--add" id="addPersonChip" data-action="start-add-person">
+            <i class="bi bi-plus"></i>Add person
+        </button>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="card shadow-sm">
-            <div class="card-header bg-light">
-                <h4 class="mb-0"><i class="bi bi-people me-2"></i>Participant Setup</h4>
+<!-- Tabs (desktop) -->
+<div class="tabs-ledger" id="desktopTabs" role="tablist">
+    <button type="button" class="tab-ledger active" role="tab" aria-selected="true" data-action="switch-tab" data-tab="add">
+        <span id="tabAddLabel">Add</span>
+    </button>
+    <button type="button" class="tab-ledger" role="tab" aria-selected="false" data-action="switch-tab" data-tab="view">
+        Expenses&nbsp;<span class="tab-count" id="expenseCountBadge" hidden></span>
+    </button>
+    <button type="button" class="tab-ledger" role="tab" aria-selected="false" data-action="switch-tab" data-tab="settle">
+        Settle up
+    </button>
+</div>
+
+<!-- Add / Edit expense -->
+<div class="tab-pane" id="pane-add">
+    <div class="card-ledger--empty" id="addEmptyState" hidden>
+        <i class="bi bi-people empty-icon"></i>
+        <div class="empty-title">Add people first</div>
+        <div class="empty-body">Expenses need someone to pay and someone to split with. Add the people in your group above to get started.</div>
+        <button type="button" class="btn-ledger" data-action="start-add-person"><i class="bi bi-plus"></i>Add a person</button>
+    </div>
+
+    <div class="card-ledger expense-form" id="expenseForm">
+        <input type="text" class="input-title" id="expenseDescription" placeholder="What was this expense for?" autocomplete="off">
+
+        <div class="form-grid">
+            <div class="form-col">
+                <div class="micro-label">Paid by</div>
+                <div class="entry-rows" id="payersList"></div>
+                <button type="button" class="btn-link-accent" data-action="add-payer"><i class="bi bi-plus"></i> Add payer</button>
             </div>
-            <div class="card-body">
-                <div class="mb-3">
-                    <label for="participantInput" class="form-label">Enter participant name</label>
-                    <input type="text" class="form-control mb-2" id="participantInput" placeholder="Enter participant name">
-                    <button class="btn btn-primary" onclick="addParticipant()">Add</button>
+            <div class="form-col">
+                <div class="col-head">
+                    <div class="micro-label">Split between</div>
+                    <button type="button" class="btn-link-accent" data-action="split-evenly">Split evenly</button>
                 </div>
-                <div id="participantList" class="mb-3"></div>
+                <div class="entry-rows" id="splitsList"></div>
+                <button type="button" class="btn-link-accent" data-action="add-split"><i class="bi bi-plus"></i> Add split</button>
             </div>
+        </div>
+
+        <div class="form-footer">
+            <span class="totals-indicator" id="totalsIndicator" aria-live="polite">
+                <i class="bi bi-circle" id="totalsIcon"></i><span id="totalsText">Enter amounts</span>
+            </span>
+            <div class="form-actions">
+                <button type="button" class="btn-link-muted" id="cancelEditBtn" data-action="cancel-edit" hidden>Cancel</button>
+                <button type="button" class="btn-ledger" id="saveExpenseBtn" data-action="save-expense">Save expense</button>
+            </div>
+        </div>
+    </div>
+    <div class="helper-text" id="addHelperText"><i class="bi bi-info-circle"></i>Amounts can be in any currency — they're converted automatically. Inactive groups may be removed after 90 days.</div>
+</div>
+
+<!-- Expenses -->
+<div class="tab-pane" id="pane-view" hidden>
+    <div class="card-ledger--empty" id="viewEmptyState" hidden>
+        <i class="bi bi-receipt empty-icon"></i>
+        <div class="empty-title">No expenses yet</div>
+        <div class="empty-body">Every expense you add shows up here with who paid and how it's split.</div>
+        <button type="button" class="btn-ledger" data-action="switch-tab" data-tab="add"><i class="bi bi-plus"></i>Add your first expense</button>
+    </div>
+
+    <div class="card-ledger expense-table-card only-desktop" id="expenseTableWrap">
+        <table class="expense-table">
+            <thead>
+                <tr>
+                    <th>Expense</th>
+                    <th>Paid by</th>
+                    <th>Split between</th>
+                    <th class="cell-amount">Amount</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody id="expenseTableBody"></tbody>
+        </table>
+        <div class="table-footer">
+            <span class="foot-count" id="expenseCountFooter"></span>
+            <span class="foot-total">Total <span id="grandTotal"></span></span>
+        </div>
+    </div>
+
+    <div class="only-mobile" id="expenseCardsWrap">
+        <div class="expense-cards" id="expenseCards"></div>
+        <div class="list-footer-m">
+            <span class="foot-count" id="expenseCountFooterMobile"></span>
+            <span class="foot-total">Total <span id="grandTotalMobile"></span></span>
         </div>
     </div>
 </div>
 
-<div class="row mb-4">
-    <div class="col-12">
-        <div class="expense-tabs-container mb-3">
-            <ul class="nav nav-tabs tab-list-mobile" role="tablist">
-                <li class="nav-item" role="presentation">
-                    <button class="nav-link active" id="add-expenses-tab" data-bs-toggle="tab" data-bs-target="#add-expenses" type="button" role="tab">
-                        <i class="bi bi-plus-lg me-2"></i><span class="d-none d-md-inline">Add Expenses</span><span class="d-inline d-md-none">Add</span>
-                    </button>
-                </li><li class="nav-item" role="presentation">
-                    <button class="nav-link" id="view-expenses-tab" data-bs-toggle="tab" data-bs-target="#view-expenses" type="button" role="tab">
-                        <i class="bi bi-table me-2"></i><span class="d-none d-md-inline">View Expenses</span><span class="d-inline d-md-none">View</span>
-                    </button>
-                </li><li class="nav-item" role="presentation">
-                    <button class="nav-link" id="settle-expenses-tab" data-bs-toggle="tab" data-bs-target="#settle-expenses" type="button" role="tab">
-                        <i class="bi bi-calculator me-2"></i><span class="d-none d-md-inline">Settle Expenses</span><span class="d-inline d-md-none">Settle</span>
-                    </button>
-                </li>
-            </ul>
-        </div>
+<!-- Settle up -->
+<div class="tab-pane" id="pane-settle" hidden>
+    <div class="card-ledger--empty" id="settleEmptyState" hidden>
+        <i class="bi bi-calculator empty-icon"></i>
+        <div class="empty-title">Nothing to settle yet</div>
+        <div class="empty-body">Once you've added expenses, we'll work out who owes what and the fewest transfers to square up.</div>
+        <button type="button" class="btn-ledger" data-action="switch-tab" data-tab="add"><i class="bi bi-plus"></i>Add an expense</button>
+    </div>
 
-        <div class="tab-content">
-            <!-- Add Expenses Tab -->
-            <div class="tab-pane fade show active" id="add-expenses" role="tabpanel">
-                <button class="btn btn-primary mb-3" onclick="addExpenseRow()">
-                    <i class="bi bi-plus-lg me-2"></i>Add Expense
+    <div class="settle-controls" id="settleControls">
+        <div class="settle-currency">
+            <label class="micro-label" for="baseCurrency">Settle in</label>
+            <select class="select-ledger" id="baseCurrency"></select>
+        </div>
+        <button type="button" class="btn-ledger" id="calculateBtn" data-action="calculate">Calculate settlement</button>
+    </div>
+
+    <div class="settle-hint" id="settleHint">
+        <i class="bi bi-arrow-up"></i>Pick a currency and calculate to see balances and the simplest transfers.
+    </div>
+
+    <div id="settlementResults" hidden>
+        <div class="settle-results">
+            <div class="balances-grid" id="balancesGrid"></div>
+            <div class="transfers-card" id="transfersCard">
+                <div class="transfers-head">
+                    <div class="micro-label">Simplest way to settle</div>
+                    <span class="tap-hint">tap to mark paid</span>
+                </div>
+                <div class="transfers-list" id="transfersList"></div>
+                <div class="all-paid-banner" id="allPaidBanner" hidden>
+                    <i class="bi bi-check-circle-fill"></i>Everyone's square. Nice trip!
+                </div>
+            </div>
+            <div class="settle-footer">
+                <span class="rates-note" id="exchangeRateInfo"></span>
+                <button type="button" class="btn-ledger btn-ledger--secondary btn-ledger--compact" data-action="export-pdf">
+                    <i class="bi bi-file-earmark-arrow-down"></i>Export PDF
                 </button>
-                <div id="expenseList" class="row g-3">
-                    <!-- Expenses will be dynamically added here -->
-                </div>
-            </div>
-
-            <!-- View Expenses Tab -->
-            <div class="tab-pane fade" id="view-expenses" role="tabpanel">
-                <!-- Desktop Table View -->
-                <div id="expenseTableContainer" class="card shadow-sm">
-                    <div class="card-header bg-light">
-                        <h4 class="mb-0"><i class="bi bi-table me-2"></i>Expenses</h4>
-                    </div>
-                    <div class="card-body">
-                        <div class="table-responsive">
-                            <table class="table table-hover">
-                                <thead>
-                                    <tr>
-                                        <th>Description</th>
-                                        <th>Who Paid</th>
-                                        <th>Amount Paid</th>
-                                        <th>Currency</th>
-                                        <th>Split Between</th>
-                                        <th>Actions</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="expenseTableBody">
-                                    <!-- Expense rows will be dynamically added here -->
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                </div>
-                
-                <!-- Mobile Card View -->
-                <div id="expenseMobileContainer" class="d-none">
-                    <div id="expenseMobileCards">
-                        <!-- Mobile expense cards will be dynamically added here -->
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Settle Expenses Tab -->
-            <div class="tab-pane fade" id="settle-expenses" role="tabpanel">
-                <div class="card shadow-sm">
-                    <div class="card-header bg-light">
-                        <h4 class="mb-0"><i class="bi bi-calculator me-2"></i>Final Settlement</h4>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <label for="baseCurrency" class="form-label">Base Currency for Settlement</label>
-                            <select class="form-select" id="baseCurrency" style="max-width: 200px;">
-                                <option value="USD">USD - US Dollar</option>
-                                <option value="EUR">EUR - Euro</option>
-                                <option value="JPY">JPY - Japanese Yen</option>
-                                <option value="GBP">GBP - British Pound</option>
-                                <option value="CNY">CNY - Chinese Yuan</option>
-                                <option value="AUD">AUD - Australian Dollar</option>
-                                <option value="CAD">CAD - Canadian Dollar</option>
-                                <option value="CHF">CHF - Swiss Franc</option>
-                                <option value="HKD">HKD - Hong Kong Dollar</option>
-                                <option value="SGD">SGD - Singapore Dollar</option>
-                                <option value="SEK">SEK - Swedish Krona</option>
-                                <option value="KRW">KRW - South Korean Won</option>
-                                <option value="INR">INR - Indian Rupee</option>
-                                <option value="BRL">BRL - Brazilian Real</option>
-                                <option value="RUB">RUB - Russian Ruble</option>
-                                <option value="ZAR">ZAR - South African Rand</option>
-                                <option value="MXN">MXN - Mexican Peso</option>
-                                <option value="IDR">IDR - Indonesian Rupiah</option>
-                                <option value="TRY">TRY - Turkish Lira</option>
-                                <option value="SAR">SAR - Saudi Riyal</option>
-                            </select>
-                        </div>
-                        <div id="exchangeRateInfo" class="text-muted small mb-3">
-                            <!-- Exchange rate info will be displayed here -->
-                        </div>
-                        <button class="btn btn-primary" onclick="calculateSettlement()">
-                            <i class="bi bi-arrow-repeat me-2"></i>Calculate Settlement
-                        </button>
-                        <div id="settlementResults" class="mt-3"></div>
-
-                        <!-- Add Export button below settlement results -->
-                        <div class="mt-4">
-                            <button class="btn btn-teal" onclick="exportToPDF()">
-                                <i class="bi bi-file-earmark-pdf me-1"></i>Export Report to PDF
-                            </button>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
 </div>
 
-<!-- Expense Entry Template -->
-<template id="expenseTemplate">
-    <div class="col-12">
-        <div class="expense-entry card shadow-sm h-100">
-            <div class="card-header bg-light">
-                <h5 class="mb-0"><i class="bi bi-receipt me-2"></i>New Expense</h5>
-            </div>
-            <div class="card-body">
-                <div class="mb-4">
-                    <label class="form-label fw-bold">Description<span class="text-danger">*</span></label>
-                    <input type="text" class="form-control expense-description" placeholder="What was this expense for?">
-                    <div class="form-text">Enter a clear description of the expense</div>
-                </div>
-                
-                <div class="mb-4">
-                    <div class="d-flex align-items-center">
-                        <label for="displayCurrencyMain" class="form-label fw-bold me-2 mb-0">Display Currency:</label>
-                        <select class="form-select display-currency-select currency-select-wide" id="displayCurrencyMain" style="max-width: 200px;" onchange="updateTotals(this)">
-                            <!-- Currency options will be populated dynamically -->
-                        </select>
-                    </div>
-                    <div class="form-text">Choose the currency shown in the expenses table for the expense below (regardless of input currency)</div>
-                </div>
-                
-                <div class="row g-4 justify-content-between">
-                    <div class="col-md-5">
-                        <div class="card border-primary mb-3">
-                            <div class="card-header bg-primary text-white">
-                                <h5 class="mb-0"><i class="bi bi-credit-card me-2"></i>Who Paid</h5>
-                            </div>
-                            <div class="card-body">
-                                <div class="payers-list mb-3"></div>
-                                <button class="btn btn-outline-primary btn-sm" onclick="addPayer(this)">
-                                    <i class="bi bi-plus-lg me-1"></i>Add Payer
-                                </button>
-                                <div class="mt-3 pt-2 border-top">
-                                    <strong>Total Paid: </strong><span class="total-paid badge bg-primary">0.00</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-5">
-                        <div class="card border-success mb-3">
-                            <div class="card-header bg-success text-white">
-                                <div class="d-flex align-items-center justify-content-between">
-                                    <h5 class="mb-0"><i class="bi-diagram-3 me-2"></i>Split Between</h5>
-                                    <button class="btn btn-sm btn-light" onclick="splitEvenly(this)">
-                                        <i class="bi bi-distribute-vertical me-1"></i>Split Evenly
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="card-body">
-                                <div class="splits-list mb-3"></div>
-                                <button class="btn btn-outline-success btn-sm" onclick="addSplit(this)">
-                                    <i class="bi bi-plus-lg me-1"></i>Add Split
-                                </button>
-                                <div class="mt-3 pt-2 border-top">
-                                    <strong>Total Split: </strong><span class="total-split badge bg-success">0.00</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="card-footer bg-light">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div class="amounts-mismatch-warning text-danger" style="display: none;">
-                        <i class="bi bi-exclamation-triangle me-1"></i>
-                        Amounts must match
-                    </div>
-                    <div class="btn-group">
-                        <button class="btn btn-success" onclick="saveExpense(this)">
-                            <i class="bi bi-check-lg me-1"></i>Save
-                        </button>
-                        <button class="btn btn-danger" onclick="removeExpense(this)">
-                            <i class="bi bi-trash"></i>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</template>
+<!-- Mobile bottom tab bar -->
+<nav class="tabbar-mobile" id="mobileTabbar">
+    <button type="button" class="active" data-action="switch-tab" data-tab="add">
+        <i class="bi bi-plus-circle-fill" id="tabAddIconMobile"></i><span id="tabAddLabelMobile">Add</span>
+    </button>
+    <button type="button" data-action="switch-tab" data-tab="view">
+        <i class="bi bi-list-ul"></i><span>Expenses</span>
+    </button>
+    <button type="button" data-action="switch-tab" data-tab="settle">
+        <i class="bi bi-arrow-left-right"></i><span>Settle</span>
+    </button>
+</nav>
 
-<!-- Payer Entry Template -->
-<template id="payerTemplate">
-    <div class="payer-entry input-group mb-2">
-        <select class="form-select payer-select">
-            <!-- Options will be populated dynamically -->
-        </select>
-        <input type="number" class="form-control amount-input" step="0.01" placeholder="Amount" onchange="updateTotals(this)">
-        <select class="form-select currency-select" onchange="updateTotals(this)">
-            <option value="USD">USD</option>
-            <option value="EUR">EUR</option>
-            <option value="GBP">GBP</option>
-            <option value="JPY">JPY</option>
-            <option value="AUD">AUD</option>
-        </select>
-        <button class="btn btn-outline-danger" onclick="removePayer(this)">×</button>
-    </div>
-</template>
-
-<!-- Split Entry Template -->
-<template id="splitTemplate">
-    <div class="split-entry input-group mb-2">
-        <select class="form-select split-select">
-            <!-- Options will be populated dynamically -->
-        </select>
-        <input type="number" class="form-control amount-input" step="0.01" placeholder="Amount" onchange="updateTotals(this)">
-        <select class="form-select currency-select" onchange="updateTotals(this)">
-            <option value="USD">USD</option>
-            <option value="EUR">EUR</option>
-            <option value="GBP">GBP</option>
-            <option value="JPY">JPY</option>
-            <option value="AUD">AUD</option>
-        </select>
-        <button class="btn btn-outline-danger" onclick="removeSplit(this)">×</button>
+<!-- Payer / split row template -->
+<template id="entryRowTemplate">
+    <div class="entry-row">
+        <select class="person-select select-ledger" aria-label="Person"></select>
+        <input type="text" inputmode="decimal" class="amount-input input-ledger" placeholder="0.00" aria-label="Amount" autocomplete="off">
+        <select class="currency-select select-ledger" aria-label="Currency"></select>
+        <button type="button" class="row-x" data-action="remove-row" aria-label="Remove row"><i class="bi bi-x"></i></button>
     </div>
 </template>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Full frontend retheme from Bootswatch Flatly to the **Ledger** design: paper-and-ink aesthetic, light/dark modes with persistence, Instrument Sans, no Bootstrap CSS/JS
- UX upgrades: inline person adding, single persistent add/edit expense form with live totals indicator, empty states, redesigned settle-up (animated balance cards, tap-to-mark-paid transfers), mobile bottom tab bar
- Settlement transfers now use greedy multi-creditor matching; PDF export reads from stored settlement state
- Header refinements: larger animated brand with tagline, share pill with auto-save note, new-sheet button; person removal blocked while they're part of an expense
- Backend and API contracts unchanged; existing databases work without migration

## Test plan
- [x] `pytest` green (8/8)
- [x] Playwright walkthrough at 1200px and 390px, light + dark: people, expense add/edit/delete, cross-currency totals, split-evenly, settle-up + transfers, invalidation, copy link, theme persistence, PDF export

🤖 Generated with [Claude Code](https://claude.com/claude-code)