### PR TITLE
Simplify mobile header

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -487,10 +487,8 @@ button:focus-visible, a:focus-visible {
     .tabs-ledger { display: none; }
     .tabbar-mobile { display: flex; }
     body { padding-bottom: calc(72px + env(safe-area-inset-bottom)); }
-    .header-inner { flex-wrap: wrap; }
-    .header-actions { width: 100%; }
-    .share-pill { flex: 1; min-width: 0; }
-    .share-pill__url { flex: 1; }
+    .share-pill { display: none; }
+    .header-note { text-align: left; margin-top: 14px; }
     /* Prevent iOS focus zoom */
     .input-ledger, .select-ledger, .chip-input { font-size: 16px; }
     .input-title { font-size: 20px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,7 +48,10 @@
                 </button>
             </div>
         </div>
-        <div class="container-ledger header-note">This link saves your group automatically (deleted after 90 days of inactivity).</div>
+        <div class="container-ledger header-note">
+            <span class="only-desktop">This link saves your group automatically (deleted after 90 days of inactivity).</span>
+            <span class="only-mobile">Your group data saves automatically at this unique URL.</span>
+        </div>
     </header>
 
     <main class="container-ledger page-main">


### PR DESCRIPTION
## Summary
- On mobile, hide the share URL pill so the New-sheet and theme-toggle buttons sit inline with the logo (the browser address bar already exposes the URL)
- Give the auto-save/retention note a shorter, left-aligned mobile-specific string with a bit more spacing above it; desktop keeps the full pill and note

## Test plan
- [x] Playwright header check at 390px (buttons inline, no URL pill, left-aligned note) and 1200px (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)