### PR TITLE
Render correct add-pane state on first paint

### DIFF
--- a/app.py
+++ b/app.py
@@ -235,7 +235,7 @@ def expense_group(group_id):
     else:
         group.last_accessed = datetime.now(UTC)
         db.session.commit()
-    return render_template("index.html", group_id=group_id)
+    return render_template("index.html", group_id=group_id, has_people=bool(group.participants))
 
 
 @app.route("/api/g/<group_id>", methods=["GET"])

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,14 +28,14 @@
 
 <!-- Add / Edit expense -->
 <div class="tab-pane" id="pane-add">
-    <div class="card-ledger--empty" id="addEmptyState" hidden>
+    <div class="card-ledger--empty" id="addEmptyState"{% if has_people %} hidden{% endif %}>
         <i class="bi bi-people empty-icon"></i>
         <div class="empty-title">Add people first</div>
         <div class="empty-body">Expenses need someone to pay and someone to split with. Add the people in your group above to get started.</div>
         <button type="button" class="btn-ledger" data-action="start-add-person"><i class="bi bi-plus"></i>Add a person</button>
     </div>
 
-    <div class="card-ledger expense-form" id="expenseForm">
+    <div class="card-ledger expense-form" id="expenseForm"{% if not has_people %} hidden{% endif %}>
         <input type="text" class="input-title" id="expenseDescription" placeholder="What was this expense for?" autocomplete="off">
 
         <div class="form-grid">
@@ -64,7 +64,7 @@
             </div>
         </div>
     </div>
-    <div class="helper-text" id="addHelperText"><i class="bi bi-info-circle"></i>Amounts can be in any currency — they're converted automatically.</div>
+    <div class="helper-text" id="addHelperText"{% if not has_people %} hidden{% endif %}><i class="bi bi-info-circle"></i>Amounts can be in any currency — they're converted automatically.</div>
 </div>
 
 <!-- Expenses -->


### PR DESCRIPTION
## Summary
- Fix a flash-of-wrong-content on fresh visits: the expense form was visible in the initial HTML and only swapped to the "Add people first" empty state after the async `/api/g/:id` fetch resolved
- The `/g/<id>` route already has the group loaded, so pass `has_people` to the template and set the initial `hidden` states server-side — no flash, no blank gap
- Client-side `updateEmptyStates()` still runs after fetch and stays consistent (idempotent)

## Test plan
- [x] `pytest` green (8/8)
- [x] Fresh group renders `addEmptyState` visible / `expenseForm` hidden in server HTML; group with people renders the inverse
- [x] Browser load of a fresh URL shows the empty state cleanly, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)