### PR TITLE
Preserve split currencies when splitting evenly

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -814,12 +814,14 @@ async function splitEvenly() {
     const baseSplitCents = Math.floor(totalPaidCents / splitRows.length);
     const remainderCents = totalPaidCents % splitRows.length;
 
-    splitRows.forEach((row, index) => {
+    for (const [index, row] of splitRows.entries()) {
         const splitCents = baseSplitCents + (index < remainderCents ? 1 : 0);
-        row.querySelector('.amount-input').value = (splitCents / 100).toFixed(2);
-        row.querySelector('.currency-select').value = DISPLAY_CURRENCY;
+        const currencySelect = row.querySelector('.currency-select');
+        const targetCurrency = currencySelect.value;
+        const rate = await getExchangeRate(DISPLAY_CURRENCY, targetCurrency);
+        row.querySelector('.amount-input').value = ((splitCents / 100) * rate).toFixed(2);
         clearEntryValidation(row);
-    });
+    }
 
     recomputeTotalsIndicator();
 }


### PR DESCRIPTION
### Motivation
- The `splitEvenly` action was forcing each split row's currency to `USD`, which caused the UI to overwrite the user's selected split currencies.
- The intent is to keep each split row's selected currency and fill amounts so the sum of splits matches the total paid in the display currency.

### Description
- Updated `static/js/app.js` in `splitEvenly()` to compute the total paid in `DISPLAY_CURRENCY`, divide the total evenly in cents, and then convert each equal share into the split row's currently selected currency before setting the amount.
- Replaced the `forEach` with an async-friendly `for...of`/`.entries()` iteration so `await getExchangeRate(...)` can be used per row.
- The change no longer overwrites the row's currency select and preserves the existing validation cleanup and totals recomputation.

### Testing
- Ran `pytest -q` and all tests passed (`8 passed` in ~1.17s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4910dc2e848333a68180130ed44eb7)